### PR TITLE
fix(ci): replace deprecated release actions with softprops/action-gh-release@v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release plugin
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+env:
+  PLUGIN_NAME: open-smart-connections
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      HUSKY: 0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Build
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+          mkdir ${{ env.PLUGIN_NAME }}
+          cp dist/main.js dist/manifest.json dist/styles.css ${{ env.PLUGIN_NAME }}
+          zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ${{ env.PLUGIN_NAME }}.zip
+            dist/main.js
+            dist/manifest.json
+            dist/styles.css


### PR DESCRIPTION
## Summary

- Remove `actions/create-release@v1` + 4× `actions/upload-release-asset@v1` (deprecated, return 403)
- Remove buggy tag extraction via `git tag --sort` (unused anyway since `softprops` reads the tag from context)
- Replace with single `softprops/action-gh-release@v2` step

## Asset mapping

`dist/main.js` → uploaded as `main.js` (softprops uses basename automatically) ✅

## Test plan
- [ ] Push a tag → GitHub Release created with `open-smart-connections.zip`, `main.js`, `manifest.json`, `styles.css`
- [ ] No deprecation warnings in Actions log

🤖 Generated with [Claude Code](https://claude.com/claude-code)