### PR TITLE
fix: connections view cached results, model switch recovery, auto re-embed

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-	"id": "open-smart-connections",
-	"name": "Open Connections",
-	"author": "beomsu koh",
-	"description": "Chat with your notes & see links to related content with Local or Remote models.",
-	"minAppVersion": "1.1.0",
-	"authorUrl": "https://github.com/beomsuKoh/obsidian-smart-connections",
-	"isDesktopOnly": true,
-	"version": "3.5.9"
+  "id": "open-smart-connections",
+  "name": "Open Connections",
+  "author": "beomsu koh",
+  "description": "Chat with your notes & see links to related content with Local or Remote models.",
+  "minAppVersion": "1.1.0",
+  "authorUrl": "https://github.com/beomsuKoh/obsidian-smart-connections",
+  "isDesktopOnly": true,
+  "version": "3.5.9"
 }

--- a/src/domain/embedding/kernel/reducer.ts
+++ b/src/domain/embedding/kernel/reducer.ts
@@ -46,6 +46,7 @@ export function reduceEmbeddingKernelState(
     case 'MODEL_SWITCH_REQUESTED':
       return {
         ...prev,
+        phase: prev.phase === 'error' ? 'idle' : prev.phase,
         lastError: null,
       };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -29,6 +29,18 @@
   border-bottom: 1px solid var(--background-modifier-border);
 }
 
+/* Info banner (stale results, model switching) */
+.osc-banner {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--osc-color-warning-bg);
+  border-bottom: 1px solid color-mix(in srgb, var(--osc-color-warning) 25%, transparent);
+  font-size: var(--font-smallest, 11px);
+  color: var(--text-muted);
+}
+
 /* Embedding progress banner */
 .osc-embed-progress {
   display: flex;
@@ -113,6 +125,19 @@
   padding: 6px 12px;
   cursor: pointer;
   transition: background-color 0.1s ease;
+  animation: osc-result-fade-in 0.2s ease both;
+  animation-delay: var(--osc-result-delay, 0ms);
+}
+
+@keyframes osc-result-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .osc-result-item:hover {

--- a/src/ui/connections/ConnectionsView.ts
+++ b/src/ui/connections/ConnectionsView.ts
@@ -31,6 +31,8 @@ export class ConnectionsView extends ItemView {
   private session: ConnectionsSessionState = { pinnedKeys: [], hiddenKeys: [], paused: false };
   private folderFilter: string = '';
   private progressEl: HTMLElement | null = null;
+  private lastRenderedPath: string | null = null;
+  private autoEmbedRequestedForPath: string | null = null;
 
   constructor(leaf: WorkspaceLeaf, plugin: SmartConnectionsPlugin) {
     super(leaf);
@@ -86,8 +88,13 @@ export class ConnectionsView extends ItemView {
     );
 
     this.registerEvent(
-      this.app.workspace.on('smart-connections:embed-state-changed' as any, () => {
+      this.app.workspace.on('smart-connections:embed-state-changed' as any, (payload: any) => {
         this.updateProgressBanner();
+        // Auto-refresh when embedding finishes and we have a stale view
+        if (payload?.event?.type === 'RUN_FINISHED' && this.lastRenderedPath) {
+          this.autoEmbedRequestedForPath = null;
+          void this.renderView(this.lastRenderedPath);
+        }
       }),
     );
 
@@ -119,95 +126,86 @@ export class ConnectionsView extends ItemView {
       return;
     }
 
+    this.lastRenderedPath = targetPath;
+
     if (!this.plugin.ready || !this.plugin.source_collection) {
       this.showLoading('Smart Connections is initializing...');
       return;
     }
 
+    if (this.plugin.status_state === 'error') {
+      this.showError(EMBED_ERROR_MSG);
+      return;
+    }
+
     const source = this.plugin.source_collection.get(targetPath);
-    const is_source_stale = !!source?.is_unembedded;
-    const kernelState = this.plugin.getEmbeddingKernelState?.();
-    const kernelPhase = kernelState?.phase;
-    const queuedTotal = kernelState?.queue?.queuedTotal ?? 0;
-    const isEmbedActive = kernelPhase === 'running';
-    const isWaitingForReembed = isEmbedActive || queuedTotal > 0;
 
     if (!source) {
       if (!this.plugin.embed_ready) {
-        if (this.plugin.status_state === 'error') {
-          this.showError(EMBED_ERROR_MSG);
-          return;
-        }
         this.showLoading(
           'Smart Connections is loading... Connections will appear when embedding is complete.',
         );
-        return;
+      } else {
+        this.showEmpty('Source not found. Check exclusion settings.');
       }
-      this.showEmpty('Source not found. Check exclusion settings.');
       return;
     }
 
-    if (!source.vec || is_source_stale) {
-      if (!this.plugin.embed_ready) {
-        if (this.plugin.status_state === 'error') {
-          this.showError(EMBED_ERROR_MSG);
-          return;
-        }
-        if (is_source_stale) {
-          if (isWaitingForReembed) {
-            this.showLoading(
-              'Embedding model switched. Re-embedding this note for the active model...',
-            );
-          } else {
-            this.showEmpty('No embedding available. The note may be too short or excluded.');
-          }
-          return;
-        }
-        const cached = await this.findCachedConnections(source);
-        if (cached.length > 0) {
-          this.renderResults(targetPath, cached);
-          this.addBanner('Embedding model loading... Results may be incomplete.');
-          return;
-        }
-        this.showLoading(
-          'Smart Connections is loading... Connections will appear when embedding is complete.',
-        );
+    const is_source_stale = !!source.is_unembedded;
+    const has_vec = !!source.vec;
+
+    // Try to show results (even if stale — old vectors still produce useful connections)
+    if (has_vec) {
+      try {
+        const results = this.plugin.source_collection.nearest_to
+          ? await this.plugin.source_collection.nearest_to(source, {})
+          : [];
+        this.renderResults(targetPath, results);
+      } catch (e) {
+        this.showError('Failed to find connections: ' + (e as Error).message);
         return;
       }
+
+      // If stale, show banner and auto-queue re-embedding
       if (is_source_stale) {
-        if (this.plugin.status_state === 'error') {
-          this.showError(EMBED_ERROR_MSG);
-          return;
-        }
-        if (isWaitingForReembed) {
-          this.showLoading(
-            'Re-embedding this note for the active model. Results will appear when ready.',
-          );
-        } else {
-          this.showEmpty('No embedding available. The note may be too short or excluded.');
-        }
-        return;
+        this.addBanner('Re-embedding in progress. Results may be from a previous model.');
+        this.autoQueueEmbedding(source);
       }
-      this.showEmpty('No embedding available. The note may be too short or excluded.');
       return;
     }
 
-    try {
-      const results = this.plugin.source_collection.nearest_to
-        ? await this.plugin.source_collection.nearest_to(source, {})
-        : [];
-      this.renderResults(targetPath, results);
-    } catch (e) {
-      this.showError('Failed to find connections: ' + (e as Error).message);
+    // No vector at all — auto-queue and show appropriate state
+    if (is_source_stale) {
+      this.autoQueueEmbedding(source);
+      this.showLoading('Embedding this note... Results will appear when ready.');
+    } else if (!this.plugin.embed_ready) {
+      this.showLoading(
+        'Smart Connections is loading... Connections will appear when embedding is complete.',
+      );
+    } else {
+      this.showEmpty('No embedding available. The note may be too short or excluded.');
     }
   }
 
-  private async findCachedConnections(source: any): Promise<any[]> {
-    if (!this.plugin.source_collection) return [];
+  /**
+   * Auto-queue the given source for re-embedding without waiting.
+   * Fire-and-forget — the view will auto-refresh on RUN_FINISHED.
+   */
+  private autoQueueEmbedding(source: any): void {
+    if (!this.plugin.embed_ready) return;
+    if (this.autoEmbedRequestedForPath === source.key) return;
+    this.autoEmbedRequestedForPath = source.key;
     try {
-      return await this.plugin.source_collection.nearest_to(source, {});
+      source.queue_embed();
+      this.plugin.embed_job_queue?.enqueue({
+        entityKey: source.key,
+        contentHash: source.read_hash || '',
+        sourcePath: source.key.split('#')[0],
+        enqueuedAt: Date.now(),
+      });
+      void this.plugin.runEmbeddingJob('Auto re-embed for connections view');
     } catch {
-      return [];
+      // Non-critical — embedding will happen via normal pipeline eventually
     }
   }
 
@@ -368,7 +366,7 @@ export class ConnectionsView extends ItemView {
 
     const list = this.container.createDiv({ cls: 'osc-results', attr: { role: 'list' } });
 
-    for (const result of filtered) {
+    for (const [idx, result] of filtered.entries()) {
       const score = result.score ?? result.sim ?? 0;
       const fullPath = result.item?.path ?? '';
       const parts = fullPath.replace(/\.md$/, '').split('/');
@@ -385,6 +383,7 @@ export class ConnectionsView extends ItemView {
           'aria-label': `${name} — ${scorePercent}% similarity`,
         },
       });
+      item.style.setProperty('--osc-result-delay', `${Math.min(idx * 25, 500)}ms`);
 
       // Score badge as percentage
       const scoreBadge = item.createSpan({ cls: 'osc-score' });

--- a/src/ui/embedding/embedding-manager.ts
+++ b/src/ui/embedding/embedding-manager.ts
@@ -543,6 +543,7 @@ function handleRunCompleted(
   stats: EmbedQueueStats,
 ): number {
   ctx.phase = 'completed';
+  plugin.current_embed_context = null;
   plugin.dispatchKernelEvent({ type: 'RUN_FINISHED' });
   plugin.notices.show('embedding_complete', { success: stats.success });
   // Clear the orchestration queue before re-scanning; queueUnembeddedEntities
@@ -718,6 +719,7 @@ async function runEmbeddingJobNow(plugin: SmartConnectionsPlugin, reason: string
     });
 
     if (plugin.active_embed_run_id !== runId) {
+      plugin.current_embed_context = null;
       plugin.dispatchKernelEvent({ type: 'RUN_FINISHED' });
       return stats;
     }
@@ -743,15 +745,21 @@ async function runEmbeddingJobNow(plugin: SmartConnectionsPlugin, reason: string
     return stats;
   } catch (error) {
     if (plugin.active_embed_run_id !== runId) {
+      plugin.current_embed_context = null;
       plugin.dispatchKernelEvent({ type: 'RUN_FINISHED' });
       throw error;
     }
+    plugin.current_embed_context = null;
     handleRunFailed(plugin, ctx, error);
     throw error;
   } finally {
     if (plugin.active_embed_run_id === runId) {
       emitEmbedProgress(plugin, ctx, { done: true });
-      plugin.current_embed_context = { ...ctx };
+      if (ctx.phase === 'failed') {
+        plugin.current_embed_context = null;
+      } else {
+        plugin.current_embed_context = { ...ctx };
+      }
       plugin.active_embed_run_id = null;
       clearEmbedNotice(plugin);
       dispatchQueueSnapshot(plugin);

--- a/test/connections-view-session.test.ts
+++ b/test/connections-view-session.test.ts
@@ -35,7 +35,11 @@ function createPluginStub() {
     block_collection: {
       data_dir: '/tmp/blocks',
     },
+    open_note: vi.fn(),
+    embed_job_queue: null,
+    runEmbeddingJob: vi.fn(async () => ({})),
     getActiveEmbeddingContext: vi.fn(() => null),
+    current_embed_context: null,
     getEmbeddingKernelState: vi.fn(() => ({
       phase: 'idle',
       queue: {
@@ -49,7 +53,16 @@ function createPluginStub() {
 function createObsidianLikeContainer(): any {
   const addHelpers = (el: HTMLElement & Record<string, any>) => {
     el.empty = function empty() {
-      this.innerHTML = '';
+      while (this.firstChild) this.removeChild(this.firstChild);
+    };
+    el.addClass = function addClass(cls: string) {
+      this.classList.add(cls);
+    };
+    el.toggleClass = function toggleClass(cls: string, force: boolean) {
+      this.classList.toggle(cls, force);
+    };
+    el.setText = function setText(text: string) {
+      this.textContent = text;
     };
     el.createDiv = function createDiv(opts: Record<string, any> = {}) {
       const div = document.createElement('div') as HTMLElement & Record<string, any>;
@@ -59,10 +72,16 @@ function createObsidianLikeContainer(): any {
       addHelpers(div);
       return div;
     };
+    el.createSpan = function createSpan(opts: Record<string, any> = {}) {
+      return this.createEl('span', opts);
+    };
     el.createEl = function createEl(tag: string, opts: Record<string, any> = {}) {
       const child = document.createElement(tag) as HTMLElement & Record<string, any>;
       if (opts.cls) child.className = opts.cls;
       if (opts.text) child.textContent = opts.text;
+      if (opts.attr) {
+        for (const [k, v] of Object.entries(opts.attr)) child.setAttribute(k, v as string);
+      }
       this.appendChild(child);
       addHelpers(child);
       return child;
@@ -75,7 +94,7 @@ function createObsidianLikeContainer(): any {
 }
 
 describe('ConnectionsView rendering states', () => {
-  it('shows empty state when source is stale but no run/queue is active', async () => {
+  it('shows cached results with banner when source is stale but has vec', async () => {
     const plugin = createPluginStub();
     plugin.status_state = 'idle';
     const staleSource = {
@@ -84,21 +103,20 @@ describe('ConnectionsView rendering states', () => {
       is_unembedded: true,
     };
     plugin.source_collection.get = vi.fn(() => staleSource);
-    plugin.source_collection.nearest_to = vi.fn(async () => [{ score: 0.9 }]);
+    plugin.source_collection.nearest_to = vi.fn(async () => [{ item: { path: 'other.md' }, score: 0.9 }]);
+    plugin.embed_job_queue = { enqueue: vi.fn() };
+    plugin.runEmbeddingJob = vi.fn(async () => ({}));
 
     const view = new ConnectionsView({} as any, plugin);
-    (view as any).container = document.createElement('div');
-    const loadingSpy = vi.spyOn(view as any, 'showLoading').mockImplementation(() => {});
-    const emptySpy = vi.spyOn(view as any, 'showEmpty').mockImplementation(() => {});
+    (view as any).container = createObsidianLikeContainer();
 
     await view.renderView('note.md');
 
-    expect(loadingSpy).not.toHaveBeenCalled();
-    expect(emptySpy).toHaveBeenCalled();
-    expect(plugin.source_collection.nearest_to).not.toHaveBeenCalled();
+    // Should show results (nearest_to was called) instead of empty/loading
+    expect(plugin.source_collection.nearest_to).toHaveBeenCalled();
   });
 
-  it('shows loading state when source is stale and queue is active', async () => {
+  it('shows cached results with banner when source is stale and queue is active', async () => {
     const plugin = createPluginStub();
     const staleSource = {
       key: 'note.md',
@@ -106,18 +124,21 @@ describe('ConnectionsView rendering states', () => {
       is_unembedded: true,
     };
     plugin.source_collection.get = vi.fn(() => staleSource);
+    plugin.source_collection.nearest_to = vi.fn(async () => [{ item: { path: 'other.md' }, score: 0.9 }]);
+    plugin.embed_job_queue = { enqueue: vi.fn() };
+    plugin.runEmbeddingJob = vi.fn(async () => ({}));
     plugin.getEmbeddingKernelState = vi.fn(() => ({
       phase: 'idle',
       queue: { queuedTotal: 1 },
     }));
 
     const view = new ConnectionsView({} as any, plugin);
-    (view as any).container = document.createElement('div');
-    const loadingSpy = vi.spyOn(view as any, 'showLoading').mockImplementation(() => {});
+    (view as any).container = createObsidianLikeContainer();
 
     await view.renderView('note.md');
 
-    expect(loadingSpy).toHaveBeenCalled();
+    // Should show results instead of loading spinner
+    expect(plugin.source_collection.nearest_to).toHaveBeenCalled();
   });
 
   it('refresh button triggers re-embed from loading state', async () => {


### PR DESCRIPTION
## Summary
- **#16**: Show cached connections with banner instead of perpetual loading spinner when source is stale
- **#5**: Allow model switch from error state (reducer resets phase on MODEL_SWITCH_REQUESTED)
- Auto-queue re-embedding for stale active note with infinite-loop guard
- Clear current_embed_context on RUN_FINISHED (fixes stale status bar)
- QMD-style 25ms stagger animation on connection result items

## Test plan
- [x] `pnpm run ci` passes (289 tests)
- [x] Code review: infinite loop guard verified, finally-block context fix applied
- [x] Simplification: dead code removed, parameter naming fixed

Closes #16, closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)