### PR TITLE
feat: search model picker + dims signal + DB rename

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,7 @@ import { EmbedJobQueue } from './domain/embedding/queue/embed-job-queue';
 
 // Core type imports needed for plugin fields
 import type { EmbedModel } from './domain/models/embed';
+import type { EmbedModelAdapter } from './types/models';
 import type { SourceCollection, BlockCollection } from './domain/entities';
 import type { EmbeddingPipeline, EmbedQueueStats } from './domain/search/embedding-pipeline';
 
@@ -145,6 +146,7 @@ export default class SmartConnectionsPlugin extends Plugin {
 
   // Core components
   embed_model?: EmbedModel;
+  _search_embed_model?: EmbedModelAdapter;
   source_collection?: SourceCollection;
   block_collection?: BlockCollection;
   embedding_pipeline?: EmbeddingPipeline;
@@ -179,6 +181,15 @@ export default class SmartConnectionsPlugin extends Plugin {
 
   get embed_ready(): boolean {
     return isEmbedReady(this.getEmbeddingKernelState());
+  }
+
+  /**
+   * Returns the adapter to use for search queries.
+   * Priority: explicit _search_embed_model > indexing adapter's embed_query > indexing adapter.
+   */
+  get search_embed_model(): EmbedModelAdapter | undefined {
+    if (this._search_embed_model) return this._search_embed_model;
+    return this.embed_model?.adapter;
   }
 
   get status_state(): EmbedStatusState {
@@ -569,6 +580,14 @@ export default class SmartConnectionsPlugin extends Plugin {
     }
     if (this.re_import_retry_timeout) {
       window.clearTimeout(this.re_import_retry_timeout);
+    }
+
+    // Unload search model adapter if separate from indexing
+    if (this._search_embed_model?.unload) {
+      this._search_embed_model.unload().catch((err: unknown) => {
+        console.warn('Failed to unload search embed model:', err);
+      });
+      this._search_embed_model = undefined;
     }
 
     // Fire-and-forget async cleanup with error handling

--- a/src/styles.css
+++ b/src/styles.css
@@ -345,6 +345,19 @@
 }
 
 
+/* ─── Dims Compatibility Signal ─── */
+.osc-dims-ok { color: var(--text-muted); }
+.osc-dims-warn { color: var(--osc-color-warning); }
+.osc-dims-error { color: var(--osc-color-error); }
+
+.osc-dims-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 4px 16px 8px;
+  font-size: var(--font-smallest, 11px);
+}
+
 /* ─── Settings ─── */
 .osc-model-status {
   display: flex;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -56,6 +56,19 @@ export interface EmbedModelSettings {
 }
 
 /**
+ * Search model configuration (optional).
+ * When set, this model is used for search queries instead of the indexing model.
+ * The adapter's API credentials are inherited from `embed_model`'s adapter config.
+ */
+export interface SearchModelSettings {
+  /** Provider name (e.g., 'upstage', 'openai') */
+  adapter: string;
+
+  /** Model key within that provider (e.g., 'embedding-query') */
+  model_key: string;
+}
+
+/**
  * Source (file) settings
  */
 export interface SourceSettings {
@@ -64,6 +77,9 @@ export interface SourceSettings {
 
   /** Embed model configuration */
   embed_model: EmbedModelSettings;
+
+  /** Search model configuration (optional, defaults to indexing model) */
+  search_model?: SearchModelSettings;
 
   /** Excluded headings (comma-separated) */
   excluded_headings: string;

--- a/src/ui/embedding/collection-manager.ts
+++ b/src/ui/embedding/collection-manager.ts
@@ -163,11 +163,20 @@ export function getEmbedAdapterSettings(embedSettings?: Record<string, any>): Re
   return settings && typeof settings === 'object' ? settings : {};
 }
 
+const STORAGE_NAMESPACE_ID = 'open-connections';
+
 function resolveStorageNamespace(plugin: SmartConnectionsPlugin, dataDir: string): string {
   const adapter: any = plugin.app.vault.adapter as any;
   const basePath = typeof adapter?.getBasePath === 'function'
     ? String(adapter.getBasePath())
     : '';
   const vaultName = plugin.app.vault.getName();
-  return `${plugin.manifest.id}:${basePath || vaultName}:${dataDir.replace(/\/(sources|blocks)$/, '')}`;
+  return `${STORAGE_NAMESPACE_ID}:${basePath || vaultName}:${dataDir.replace(/\/(sources|blocks)$/, '')}`;
+}
+
+/**
+ * Compute the legacy storage namespace (pre-rename) for migration checks.
+ */
+export function resolveLegacyStorageNamespace(pluginId: string, basePath: string, vaultName: string, dataDir: string): string {
+  return `${pluginId}:${basePath || vaultName}:${dataDir.replace(/\/(sources|blocks)$/, '')}`;
 }

--- a/src/ui/embedding/embedding-manager.ts
+++ b/src/ui/embedding/embedding-manager.ts
@@ -256,6 +256,55 @@ export async function initEmbedModel(plugin: SmartConnectionsPlugin): Promise<vo
   }
 }
 
+// ── Search model initialization ─────────────────────────────────────
+
+/**
+ * Initialize a separate search embed model if configured.
+ * When `search_model` is set in settings, creates a dedicated adapter for queries.
+ * Otherwise, clears any existing search model (queries use the indexing adapter).
+ */
+export async function initSearchEmbedModel(plugin: SmartConnectionsPlugin): Promise<void> {
+  const searchModelSettings = plugin.settings.smart_sources.search_model;
+  if (!searchModelSettings?.adapter || !searchModelSettings?.model_key) {
+    plugin._search_embed_model = undefined;
+    return;
+  }
+
+  // If search model matches indexing model, no separate adapter needed
+  const embedSettings = plugin.settings.smart_sources.embed_model;
+  const indexingAdapterSettings = plugin.getEmbedAdapterSettings(embedSettings);
+  if (
+    searchModelSettings.adapter === embedSettings.adapter &&
+    searchModelSettings.model_key === (indexingAdapterSettings.model_key || '')
+  ) {
+    plugin._search_embed_model = undefined;
+    return;
+  }
+
+  try {
+    // Inherit API credentials from the search adapter's config in embed_model
+    const searchAdapterSettings = searchModelSettings.adapter === embedSettings.adapter
+      ? { ...indexingAdapterSettings }
+      : { ...(embedSettings[searchModelSettings.adapter as keyof typeof embedSettings] as Record<string, any> || {}) };
+
+    const { adapter, requiresLoad } = embedAdapterRegistry.createAdapter(
+      searchModelSettings.adapter,
+      searchModelSettings.model_key,
+      searchAdapterSettings,
+    );
+
+    if (requiresLoad && typeof (adapter as any).load === 'function') {
+      await (adapter as any).load();
+    }
+
+    plugin._search_embed_model = adapter as any;
+    console.log(`[SC][Init]   [search-model] Search model initialized ✓ (${searchModelSettings.adapter}/${searchModelSettings.model_key})`);
+  } catch (error) {
+    console.warn('[SC][Init]   [search-model] Failed to initialize search model, will use indexing model:', error);
+    plugin._search_embed_model = undefined;
+  }
+}
+
 // ── Pipeline initialization ─────────────────────────────────────────
 
 export function initPipeline(plugin: SmartConnectionsPlugin): void {
@@ -320,6 +369,16 @@ function haltActivePipelineForSwitch(
 }
 
 async function unloadPreviousModel(plugin: SmartConnectionsPlugin): Promise<void> {
+  // Unload search model first (if separate adapter)
+  if (plugin._search_embed_model?.unload) {
+    try {
+      await plugin._search_embed_model.unload();
+    } catch (error) {
+      console.warn('Failed to unload previous search embed model during switch:', error);
+    }
+    plugin._search_embed_model = undefined;
+  }
+
   if (!plugin.embed_model) return;
   try {
     await plugin.embed_model.unload();
@@ -410,6 +469,11 @@ async function switchEmbeddingModelNow(plugin: SmartConnectionsPlugin, reason: s
       `Timed out while loading embedding model (${targetAdapter}/${targetModelKey}).`,
     );
     console.log(`[SC][Init]   [switch] Model loaded ✓ (${(performance.now() - t).toFixed(0)}ms)`);
+
+    // Initialize search model if configured
+    t = performance.now();
+    await initSearchEmbedModel(plugin);
+    console.log(`[SC][Init]   [switch] Search model init ✓ (${(performance.now() - t).toFixed(0)}ms)`);
 
     t = performance.now();
     console.log('[SC][Init]   [switch] Syncing collection embedding context...');

--- a/src/ui/lookup/LookupView.ts
+++ b/src/ui/lookup/LookupView.ts
@@ -251,7 +251,15 @@ export class LookupView extends ItemView {
         return;
       }
 
-      const embedResults = await this.plugin.embed_model.adapter.embed_batch([{ _embed_input: query }]);
+      // Use search model (supports asymmetric embedding like Upstage query/passage split)
+      const searchAdapter = this.plugin.search_embed_model;
+      if (!searchAdapter) {
+        this.showError('No embedding adapter available.');
+        return;
+      }
+      const embedResults = typeof searchAdapter.embed_query === 'function'
+        ? await searchAdapter.embed_query(query)
+        : await searchAdapter.embed_batch([{ _embed_input: query }]);
       const queryVec = embedResults?.[0]?.vec;
       if (!queryVec || queryVec.length === 0) {
         this.showError('Failed to embed search query.');

--- a/src/ui/models/embed/adapters/upstage.ts
+++ b/src/ui/models/embed/adapters/upstage.ts
@@ -31,11 +31,20 @@ export const UPSTAGE_SIGNUP_URL = 'https://console.upstage.ai/';
 export const UPSTAGE_EMBED_MODELS: Record<string, ModelInfo> = {
   'embedding-passage': {
     model_key: 'embedding-passage',
-    model_name: 'Upstage Solar',
+    model_name: 'Upstage Solar (passage)',
     batch_size: 50,
     dims: 4096,
     max_tokens: 4000,
-    description: 'API, 4,000 tokens, 4,096 dim — Korean-optimized (auto query/passage split)',
+    description: 'API, 4,000 tokens, 4,096 dim — Korean-optimized, for indexing documents',
+    endpoint: 'https://api.upstage.ai/v1/embeddings',
+  },
+  'embedding-query': {
+    model_key: 'embedding-query',
+    model_name: 'Upstage Solar (query)',
+    batch_size: 50,
+    dims: 4096,
+    max_tokens: 4000,
+    description: 'API, 4,000 tokens, 4,096 dim — Korean-optimized, for search queries',
     endpoint: 'https://api.upstage.ai/v1/embeddings',
   },
 };

--- a/src/ui/settings-model-picker.ts
+++ b/src/ui/settings-model-picker.ts
@@ -343,3 +343,139 @@ export function renderHostField(
       });
     });
 }
+
+// ── Search Model Picker ─────────────────────────────────────────────
+
+interface SearchModelPickerDeps {
+  containerEl: HTMLElement;
+  config: ConfigAccessor;
+  onChanged: () => void;
+  display: () => void;
+}
+
+/** Resolve dims for a given adapter + model_key from the registry. */
+function resolveModelDims(adapterName: string, modelKey: string): number | null {
+  const reg = embedAdapterRegistry.get(adapterName);
+  if (!reg) return null;
+  const info = reg.models[modelKey];
+  return info?.dims ?? null;
+}
+
+type DimsSignal = 'ok' | 'warn' | 'error';
+
+function computeDimsSignal(
+  indexingAdapter: string,
+  indexingDims: number | null,
+  searchAdapter: string,
+  searchDims: number | null,
+): DimsSignal {
+  if (indexingDims == null || searchDims == null) return 'ok';
+  if (indexingDims !== searchDims) return 'error';
+  if (indexingAdapter !== searchAdapter) return 'warn';
+  return 'ok';
+}
+
+const DIMS_SIGNAL_TOOLTIPS: Record<DimsSignal, string> = {
+  ok: 'Same provider and dimensions — fully compatible',
+  warn: 'Different provider but same dimensions — should work, verify quality',
+  error: 'Dimension mismatch — search results will be incompatible',
+};
+
+/**
+ * Render the search model picker section with dims compatibility signal.
+ */
+export function renderSearchModelPicker(deps: SearchModelPickerDeps): void {
+  const { containerEl, config, onChanged, display } = deps;
+
+  const indexingAdapter = config.getConfig('smart_sources.embed_model.adapter', 'transformers');
+  const indexingModelKey = config.getConfig(
+    `smart_sources.embed_model.${indexingAdapter}.model_key`,
+    '',
+  );
+  const indexingDims = resolveModelDims(indexingAdapter, indexingModelKey);
+
+  const searchAdapter = config.getConfig('smart_sources.search_model.adapter', '');
+  const searchModelKey = config.getConfig('smart_sources.search_model.model_key', '');
+  const isSearchModelSet = searchAdapter !== '' && searchModelKey !== '';
+
+  // Heading
+  new Setting(containerEl).setName('Search Model (optional)').setHeading();
+
+  // Provider dropdown
+  new Setting(containerEl)
+    .setName('Search provider')
+    .setDesc('Provider used for search queries. "Same as indexing" uses the indexing model.')
+    .addDropdown((dropdown) => {
+      dropdown.addOption('', 'Same as indexing');
+
+      for (const reg of embedAdapterRegistry.getAll()) {
+        dropdown.addOption(reg.name, reg.displayName);
+      }
+
+      dropdown.setValue(searchAdapter);
+      dropdown.onChange((value) => {
+        if (value === '') {
+          // Clear search model — revert to indexing model
+          config.setConfig('smart_sources.search_model', undefined as any);
+          onChanged();
+          display();
+          return;
+        }
+
+        // Set provider, auto-select first model
+        const reg = embedAdapterRegistry.get(value);
+        const firstModelKey = reg ? Object.keys(reg.models)[0] ?? '' : '';
+        config.setConfig('smart_sources.search_model', {
+          adapter: value,
+          model_key: firstModelKey,
+        });
+        onChanged();
+        display();
+      });
+    });
+
+  // Model dropdown (only when a search provider is selected)
+  if (isSearchModelSet) {
+    const allKnownModels = getKnownModels();
+    const searchModels = allKnownModels[searchAdapter] ?? [];
+
+    if (searchModels.length > 0) {
+      new Setting(containerEl)
+        .setName('Search model')
+        .setDesc('Model used for embedding search queries')
+        .addDropdown((dropdown) => {
+          for (const m of searchModels) {
+            dropdown.addOption(m.value, m.name);
+          }
+          dropdown.setValue(searchModelKey);
+          dropdown.onChange((value) => {
+            config.setConfig('smart_sources.search_model', {
+              adapter: searchAdapter,
+              model_key: value,
+            });
+            onChanged();
+            display();
+          });
+        });
+    }
+
+    // Dims comparison signal
+    const searchDims = resolveModelDims(searchAdapter, searchModelKey);
+    const signal = computeDimsSignal(indexingAdapter, indexingDims, searchAdapter, searchDims);
+
+    const dimsRow = containerEl.createDiv({ cls: 'osc-dims-row' });
+
+    const indexLabel = dimsRow.createSpan({
+      text: `Indexing: ${indexingDims != null ? `${indexingDims}d` : '?'}`,
+      cls: 'osc-dims-ok',
+    });
+    indexLabel.setAttribute('aria-label', 'Indexing model dimensions');
+
+    const searchLabel = dimsRow.createSpan({
+      text: `Search: ${searchDims != null ? `${searchDims}d` : '?'}`,
+      cls: `osc-dims-${signal}`,
+    });
+    searchLabel.setAttribute('aria-label', DIMS_SIGNAL_TOOLTIPS[signal]);
+    searchLabel.title = DIMS_SIGNAL_TOOLTIPS[signal];
+  }
+}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -17,6 +17,7 @@ import {
   renderModelDropdown,
   renderApiKeyField as renderApiKeyFieldExternal,
   renderHostField as renderHostFieldExternal,
+  renderSearchModelPicker,
 } from './settings-model-picker';
 
 interface SmartConnectionsPlugin extends Plugin {
@@ -188,6 +189,14 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
       const defaultHost = currentAdapter === 'ollama' ? 'http://localhost:11434' : 'http://localhost:1234';
       renderHostFieldExternal(containerEl, currentAdapter, defaultHost, configAccessor);
     }
+
+    // Search model section
+    renderSearchModelPicker({
+      containerEl,
+      config: configAccessor,
+      onChanged: () => this.triggerSearchModelReInit(),
+      display: () => this.display(),
+    });
   }
 
   private ensureModelKeyForAdapter(adapterName: string): void {
@@ -196,6 +205,10 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
       '',
     );
     if (typeof existing === 'string' && existing.trim().length > 0) {
+      // Still apply Upstage search model auto-population
+      if (adapterName === 'upstage') {
+        this.autoPopulateUpstageSearchModel();
+      }
       return;
     }
 
@@ -204,11 +217,23 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
       ollama: 'bge-m3',
       openai: 'text-embedding-3-small',
       gemini: 'text-embedding-004',
-      upstage: 'solar-embedding-1-large-passage',
+      upstage: 'embedding-passage',
     };
     const fallback = defaults[adapterName];
     if (!fallback) return;
     this.setConfig(`smart_sources.embed_model.${adapterName}.model_key`, fallback);
+
+    // Auto-populate search model for Upstage (asymmetric embedding)
+    if (adapterName === 'upstage') {
+      this.autoPopulateUpstageSearchModel();
+    }
+  }
+
+  private autoPopulateUpstageSearchModel(): void {
+    this.setConfig('smart_sources.search_model', {
+      adapter: 'upstage',
+      model_key: 'embedding-query',
+    });
   }
 
   private renderSourceSettings(containerEl: HTMLElement): void {
@@ -537,5 +562,12 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
       plugin.notices?.show?.('failed_reinitialize_model');
       console.error('Re-embed failed:', e);
     }
+  }
+
+  private triggerSearchModelReInit(): void {
+    // Re-init search model without re-embedding (search model change doesn't affect stored vectors)
+    this.plugin.switchEmbeddingModel?.('Search model changed').catch((e) => {
+      console.error('Search model re-init failed:', e);
+    });
   }
 }

--- a/test/lookup-model-switch.test.ts
+++ b/test/lookup-model-switch.test.ts
@@ -8,13 +8,13 @@ import { LookupView } from '../src/ui/lookup/LookupView';
 
 function createPluginStub() {
   const nearest = vi.fn().mockResolvedValue([]);
+  const adapter = {
+    embed_batch: vi.fn().mockResolvedValue([{ vec: [1, 0] }]),
+  };
   return {
     embed_ready: true,
-    embed_model: {
-      adapter: {
-        embed_batch: vi.fn().mockResolvedValue([{ vec: [1, 0] }]),
-      },
-    },
+    embed_model: { adapter },
+    search_embed_model: adapter,
     source_collection: {
       all: [],
       nearest,


### PR DESCRIPTION
## Summary
- **Search model picker**: Optional separate model for search queries (cross-provider support)
- **Dims compatibility signal**: Color-coded dims text (red=mismatch, yellow=cross-provider, default=OK)
- **LookupView bug fix**: Uses `embed_query()` for asymmetric models (Upstage query/passage split)
- **Upstage improvements**: Auto-populate `embedding-query`, register in catalog, fix stale default
- **DB namespace rename**: Storage namespace changed to `open-connections`

## Test plan
- [x] `pnpm run ci` passes (289 tests, 0 lint errors)
- [ ] Deploy to Ataraxia vault, verify search model section in Settings
- [ ] Test Lookup with Upstage asymmetric embedding
- [ ] Test dims signal with cross-provider selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)