### PR TITLE
refactor: flatten folder structure and normalize file naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,20 +100,17 @@ src/
 │   ├── commands.ts           # Command palette registrations
 │   ├── status-bar.ts         # Status bar widget
 │   ├── file-watcher.ts       # Vault file change handlers
-│   ├── user-state.ts         # Install date, version tracking, update checks
-│   ├── connections/
-│   │   └── ConnectionsView.ts   # ItemView: related notes for active file
-│   ├── lookup/
-│   │   └── LookupView.ts        # ItemView: semantic search across vault
+│   ├── user-state.ts         # Install date, version tracking
+│   ├── ConnectionsView.ts       # ItemView: related notes for active file
+│   ├── LookupView.ts            # ItemView: semantic search across vault
+│   ├── result-context-menu.ts   # Right-click context menu for results
 │   ├── embedding/
-│   │   ├── collection-manager.ts # Source/Block collection init and loading
-│   │   └── embedding-manager.ts  # Model lifecycle, embed jobs, pipeline
-│   ├── models/embed/adapters/   # API adapters (use requestUrl — Obsidian-dependent)
-│   │   ├── _api.ts           # Shared fetch helper
-│   │   ├── transformers.ts   # Local WebWorker adapter
-│   │   ├── openai.ts, gemini.ts, ollama.ts, lm_studio.ts, open_router.ts, upstage.ts
-│   └── views/
-│       └── result-context-menu.ts  # Right-click context menu for results
+│   │   ├── collection-loader.ts  # Source/Block collection init and loading
+│   │   └── embed-orchestrator.ts # Model lifecycle, embed jobs, pipeline
+│   └── models/embed/adapters/   # API adapters (use requestUrl — Obsidian-dependent)
+│       ├── api-base.ts       # Base adapter classes
+│       ├── transformers.ts   # Local WebWorker adapter
+│       ├── openai.ts, gemini.ts, ollama.ts, lm-studio.ts, open-router.ts, upstage.ts
 ├── types/                    # Pure type definitions — NO obsidian imports
 │   ├── entities.ts
 │   ├── models.ts
@@ -213,8 +210,8 @@ pnpm vitest run test/notices.test.ts
 | `src/shared/plugin-logger.ts` | Shared PluginLogger (synced from boiler template — do not edit) |
 | `src/domain/config.ts` | DEFAULT_SETTINGS |
 | `src/types/obsidian-shims.ts` | Structural shims for TFile, Vault, MetadataCache — used by domain layer |
-| `src/ui/connections/ConnectionsView.ts` | Connections panel (related notes) |
-| `src/ui/lookup/LookupView.ts` | Semantic search panel |
+| `src/ui/ConnectionsView.ts` | Connections panel (related notes) |
+| `src/ui/LookupView.ts` | Semantic search panel |
 | `src/domain/embedding/kernel/store.ts` | Embedding state machine |
 | `src/domain/entities/` | Source/Block entity model + SQLite adapter |
 | `src/domain/models/embed/` | Abstract EmbedModel + registry |

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-	"id": "open-connections",
-	"name": "Open Connections",
-	"author": "beomsu koh",
-	"description": "Chat with your notes & see links to related content with Local or Remote models.",
-	"minAppVersion": "1.1.0",
-	"authorUrl": "https://github.com/beomsuKoh/obsidian-smart-connections",
-	"isDesktopOnly": true,
-	"version": "3.7.2"
+  "id": "open-connections",
+  "name": "Open Connections",
+  "author": "beomsu koh",
+  "description": "Chat with your notes & see links to related content with Local or Remote models.",
+  "minAppVersion": "1.1.0",
+  "authorUrl": "https://github.com/beomsuKoh/obsidian-smart-connections",
+  "isDesktopOnly": true,
+  "version": "3.7.2"
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,8 +15,8 @@ import { SmartConnectionsNotices, NOTICE_CATALOG } from './domain/notices';
 import { PluginLogger } from './shared/plugin-logger';
 import { SmartConnectionsSettingsTab } from './ui/settings';
 import { registerCommands } from './ui/commands';
-import { ConnectionsView, CONNECTIONS_VIEW_TYPE } from './ui/connections/ConnectionsView';
-import { LookupView, LOOKUP_VIEW_TYPE } from './ui/lookup/LookupView';
+import { ConnectionsView, CONNECTIONS_VIEW_TYPE } from './ui/ConnectionsView';
+import { LookupView, LOOKUP_VIEW_TYPE } from './ui/LookupView';
 import { setupStatusBar as _setupStatusBar, refreshStatus as _refreshStatus, handleStatusBarClick as _handleStatusBarClick } from './ui/status-bar';
 import {
   loadUserState as _loadUserState,
@@ -36,7 +36,7 @@ import {
   getEmbeddingQueueSnapshot as _getEmbeddingQueueSnapshot,
   syncCollectionEmbeddingContext as _syncCollectionEmbeddingContext,
   getEmbedAdapterSettings as _getEmbedAdapterSettings,
-} from './ui/embedding/collection-manager';
+} from './ui/embedding/collection-loader';
 import {
   registerFileWatchers as _registerFileWatchers,
   isSourceFile as _isSourceFile,
@@ -56,7 +56,7 @@ import {
   getActiveEmbeddingContext as _getActiveEmbeddingContext,
   logEmbed as _logEmbed,
   clearEmbedNotice as _clearEmbedNotice,
-} from './ui/embedding/embedding-manager';
+} from './ui/embedding/embed-orchestrator';
 import { EmbeddingKernelStore } from './domain/embedding/kernel/store';
 import { EmbeddingKernelJobQueue } from './domain/embedding/kernel/queue';
 import {

--- a/src/ui/ConnectionsView.ts
+++ b/src/ui/ConnectionsView.ts
@@ -6,8 +6,8 @@ import {
   Menu,
   setIcon,
 } from 'obsidian';
-import type SmartConnectionsPlugin from '../../main';
-import { showResultContextMenu } from '../views/result-context-menu';
+import type SmartConnectionsPlugin from '../main';
+import { showResultContextMenu } from './result-context-menu';
 
 export const CONNECTIONS_VIEW_TYPE = 'smart-connections-view';
 

--- a/src/ui/LookupView.ts
+++ b/src/ui/LookupView.ts
@@ -1,7 +1,7 @@
 import { ItemView, WorkspaceLeaf, ButtonComponent, debounce, setIcon, Platform } from 'obsidian';
-import type SmartConnectionsPlugin from '../../main';
-import type { SearchFilter, ConnectionResult } from '../../types/entities';
-import { showResultContextMenu } from '../views/result-context-menu';
+import type SmartConnectionsPlugin from '../main';
+import type { SearchFilter, ConnectionResult } from '../types/entities';
+import { showResultContextMenu } from './result-context-menu';
 
 export const LOOKUP_VIEW_TYPE = 'smart-connections-lookup';
 

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -4,8 +4,8 @@
  */
 
 import type { Plugin } from 'obsidian';
-import { ConnectionsView } from './connections/ConnectionsView';
-import { LookupView } from './lookup/LookupView';
+import { ConnectionsView } from './ConnectionsView';
+import { LookupView } from './LookupView';
 
 /**
  * Register all plugin commands

--- a/src/ui/embedding/collection-loader.ts
+++ b/src/ui/embedding/collection-loader.ts
@@ -1,5 +1,5 @@
 /**
- * @file embedding/collection-manager.ts
+ * @file embedding/collection-loader.ts
  * @description Collection initialization, loading, and embedding context sync
  */
 

--- a/src/ui/embedding/embed-orchestrator.ts
+++ b/src/ui/embedding/embed-orchestrator.ts
@@ -1,11 +1,11 @@
 /**
- * @file embedding/embedding-manager.ts
+ * @file embedding/embed-orchestrator.ts
  * @description Embedding model initialization, pipeline management, run orchestration, notices, and progress events
  */
 
 import type SmartConnectionsPlugin from '../../main';
 import type { EmbeddingRunContext, EmbedProgressEventPayload } from '../../main';
-import { CONNECTIONS_VIEW_TYPE } from '../connections/ConnectionsView';
+import { CONNECTIONS_VIEW_TYPE } from '../ConnectionsView';
 
 import { EmbedModel, embedAdapterRegistry } from '../../domain/models/embed';
 // Import adapters to trigger self-registration
@@ -13,9 +13,9 @@ import '../models/embed/adapters/transformers';
 import '../models/embed/adapters/openai';
 import '../models/embed/adapters/ollama';
 import '../models/embed/adapters/gemini';
-import '../models/embed/adapters/lm_studio';
+import '../models/embed/adapters/lm-studio';
 import '../models/embed/adapters/upstage';
-import '../models/embed/adapters/open_router';
+import '../models/embed/adapters/open-router';
 
 import {
   EmbeddingPipeline,
@@ -23,7 +23,7 @@ import {
 } from '../../domain/search/embedding-pipeline';
 import {
   getEmbeddingQueueSnapshot,
-} from './collection-manager';
+} from './collection-loader';
 import { buildKernelModel } from '../../domain/embedding/kernel/effects';
 import type { EmbeddingKernelJobType } from '../../domain/embedding/kernel/types';
 

--- a/src/ui/models/embed/adapters/api-base.ts
+++ b/src/ui/models/embed/adapters/api-base.ts
@@ -1,5 +1,5 @@
 /**
- * @file _api.ts
+ * @file api-base.ts
  * @description Base adapter classes for API-based embedding models
  */
 

--- a/src/ui/models/embed/adapters/gemini.ts
+++ b/src/ui/models/embed/adapters/gemini.ts
@@ -7,7 +7,7 @@ import {
   EmbedModelApiAdapter,
   EmbedModelRequestAdapter,
   EmbedModelResponseAdapter,
-} from './_api';
+} from './api-base';
 import type { EmbedInput, EmbedResult, ModelInfo } from '../../../../types/models';
 import { embedAdapterRegistry } from '../../../../domain/models/embed/registry';
 

--- a/src/ui/models/embed/adapters/lm-studio.ts
+++ b/src/ui/models/embed/adapters/lm-studio.ts
@@ -1,5 +1,5 @@
 /**
- * @file lm_studio.ts
+ * @file lm-studio.ts
  * @description Adapter for LM Studio's local embedding API
  */
 
@@ -8,7 +8,7 @@ import {
   EmbedModelApiAdapter,
   EmbedModelRequestAdapter,
   EmbedModelResponseAdapter,
-} from './_api';
+} from './api-base';
 import type { EmbedInput, EmbedResult, ModelInfo } from '../../../../types/models';
 import { embedAdapterRegistry } from '../../../../domain/models/embed/registry';
 

--- a/src/ui/models/embed/adapters/ollama.ts
+++ b/src/ui/models/embed/adapters/ollama.ts
@@ -8,7 +8,7 @@ import {
   EmbedModelApiAdapter,
   EmbedModelRequestAdapter,
   EmbedModelResponseAdapter,
-} from './_api';
+} from './api-base';
 import type { EmbedResult, ModelInfo } from '../../../../types/models';
 import { embedAdapterRegistry } from '../../../../domain/models/embed/registry';
 

--- a/src/ui/models/embed/adapters/open-router.ts
+++ b/src/ui/models/embed/adapters/open-router.ts
@@ -1,5 +1,5 @@
 /**
- * @file open_router.ts
+ * @file open-router.ts
  * @description Adapter for OpenRouter's embedding API
  */
 
@@ -8,7 +8,7 @@ import {
   EmbedModelApiAdapter,
   EmbedModelRequestAdapter,
   EmbedModelResponseAdapter,
-} from './_api';
+} from './api-base';
 import type { EmbedResult, ModelInfo } from '../../../../types/models';
 import { embedAdapterRegistry } from '../../../../domain/models/embed/registry';
 

--- a/src/ui/models/embed/adapters/openai.ts
+++ b/src/ui/models/embed/adapters/openai.ts
@@ -7,7 +7,7 @@ import {
   EmbedModelApiAdapter,
   EmbedModelRequestAdapter,
   EmbedModelResponseAdapter,
-} from './_api';
+} from './api-base';
 import type { EmbedResult, ModelInfo } from '../../../../types/models';
 import { embedAdapterRegistry } from '../../../../domain/models/embed/registry';
 

--- a/src/ui/models/embed/adapters/upstage.ts
+++ b/src/ui/models/embed/adapters/upstage.ts
@@ -7,7 +7,7 @@ import {
   EmbedModelApiAdapter,
   EmbedModelRequestAdapter,
   EmbedModelResponseAdapter,
-} from './_api';
+} from './api-base';
 import type { EmbedResult, ModelInfo } from '../../../../types/models';
 import { embedAdapterRegistry } from '../../../../domain/models/embed/registry';
 

--- a/src/ui/result-context-menu.ts
+++ b/src/ui/result-context-menu.ts
@@ -1,5 +1,5 @@
 /**
- * @file views/result-context-menu.ts
+ * @file result-context-menu.ts
  * @description Shared context menu for result items in ConnectionsView and LookupView
  */
 

--- a/src/ui/status-bar.ts
+++ b/src/ui/status-bar.ts
@@ -5,7 +5,7 @@
 
 import { setIcon } from 'obsidian';
 import type SmartConnectionsPlugin from '../main';
-import { ConnectionsView } from './connections/ConnectionsView';
+import { ConnectionsView } from './ConnectionsView';
 
 /**
  * Create the status bar item, wire up click handler, and render initial state.

--- a/src/ui/user-state.ts
+++ b/src/ui/user-state.ts
@@ -4,7 +4,7 @@
  */
 
 import type SmartConnectionsPlugin from '../main';
-import { ConnectionsView } from './connections/ConnectionsView';
+import { ConnectionsView } from './ConnectionsView';
 import { determine_installed_at } from '../utils/determine_installed_at';
 
 export async function loadUserState(plugin: SmartConnectionsPlugin): Promise<void> {

--- a/test/adapter-registry.test.ts
+++ b/test/adapter-registry.test.ts
@@ -13,9 +13,9 @@ import '../src/ui/models/embed/adapters/transformers';
 import '../src/ui/models/embed/adapters/openai';
 import '../src/ui/models/embed/adapters/ollama';
 import '../src/ui/models/embed/adapters/gemini';
-import '../src/ui/models/embed/adapters/lm_studio';
+import '../src/ui/models/embed/adapters/lm-studio';
 import '../src/ui/models/embed/adapters/upstage';
-import '../src/ui/models/embed/adapters/open_router';
+import '../src/ui/models/embed/adapters/open-router';
 
 // Import model catalogs for verification
 import { TRANSFORMERS_EMBED_MODELS } from '../src/ui/models/embed/adapters/transformers';

--- a/test/connections-view-session.test.ts
+++ b/test/connections-view-session.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { ConnectionsView } from '../src/ui/connections/ConnectionsView';
+import { ConnectionsView } from '../src/ui/ConnectionsView';
 
 function createPluginStub() {
   return {

--- a/test/entities.test.ts
+++ b/test/entities.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { EmbeddingEntity } from '../src/domain/entities/EmbeddingEntity';
 import { EntityCollection } from '../src/domain/entities/EntityCollection';
-import { getEmbedAdapterSettings } from '../src/ui/embedding/collection-manager';
+import { getEmbedAdapterSettings } from '../src/ui/embedding/collection-loader';
 import type { EntityData } from '../src/types/entities';
 
 describe('EmbeddingEntity', () => {

--- a/test/lookup-model-switch.test.ts
+++ b/test/lookup-model-switch.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { LookupView } from '../src/ui/lookup/LookupView';
+import { LookupView } from '../src/ui/LookupView';
 
 function createPluginStub() {
   const nearest = vi.fn().mockResolvedValue([]);


### PR DESCRIPTION
## Summary

- **Flatten single-file UI dirs**: `connections/`, `lookup/`, `views/` → files moved directly into `ui/`
- **Normalize adapter names**: `_api.ts` → `api-base.ts`, `lm_studio.ts` → `lm-studio.ts`, `open_router.ts` → `open-router.ts`
- **Clarify module names**: `embedding-manager.ts` → `embed-orchestrator.ts`, `collection-manager.ts` → `collection-loader.ts`
- **Delete ghost dirs**: empty `domain/config/` and `domain/errors/`

No logic changes — purely structural (git mv + import path updates).

## Test plan

- [x] CI passes (233 tests, lint, build)
- [ ] Plugin loads without errors

🤖 Generated with [Claude Code](https://claude.ai/code)