### PR TITLE
feat: configurable embedding save interval

### DIFF
--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -14,6 +14,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   language: 'en',
   new_user: true,
   re_import_wait_time: 13,
+  embed_save_interval: 5,
   is_obsidian_vault: true,
 
   smart_sources: {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -140,6 +140,9 @@ export interface PluginSettings {
   /** Re-import wait time in seconds */
   re_import_wait_time: number;
 
+  /** How often to save embedding progress (in batches). Lower = safer on crash, higher = less I/O */
+  embed_save_interval: number;
+
   /** Whether this is an Obsidian vault */
   is_obsidian_vault: boolean;
 

--- a/src/ui/embedding/embed-orchestrator.ts
+++ b/src/ui/embedding/embed-orchestrator.ts
@@ -774,7 +774,7 @@ async function runEmbeddingJobNow(plugin: SmartConnectionsPlugin, reason: string
       max_retries: 3,
       on_progress: createProgressCallback(plugin, runId, ctx),
       on_save: createSaveCallback(plugin, runId, ctx),
-      save_interval: 50,
+      save_interval: plugin.settings.embed_save_interval || 5,
     });
 
     if (plugin.active_embed_run_id !== runId) {

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -315,6 +315,19 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
           this.setConfig('smart_blocks.min_chars', parseInt(value) || 200);
         });
       });
+
+    new Setting(containerEl)
+      .setName('Save frequency')
+      .setDesc('Save progress every N batches. Lower = safer on crash, higher = less disk I/O')
+      .addSlider((slider) => {
+        slider
+          .setLimits(1, 50, 1)
+          .setValue(this.getConfig('embed_save_interval', 5))
+          .setDynamicTooltip()
+          .onChange(async (value) => {
+            this.setConfig('embed_save_interval', value);
+          });
+      });
   }
 
   private renderViewSettings(containerEl: HTMLElement): void {


### PR DESCRIPTION
## Summary

- Adds **Save frequency** slider (1-50 batches) in Settings > Block settings
- Controls how often embedding progress is persisted to SQLite during a run
- Default: 5 batches (was hardcoded 50) — reduces worst-case crash data loss from ~500 to ~50 entities
- Lower = safer on crash, higher = less disk I/O

## Test plan

- [x] CI passes (233 tests)
- [ ] Settings slider renders and persists value
- [ ] Embedding run respects the configured interval

🤖 Generated with [Claude Code](https://claude.ai/code)