### PR TITLE
feat: block-only embedding architecture + parallel pipeline

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-	"id": "open-connections",
-	"name": "Open Connections",
-	"author": "beomsu koh",
-	"description": "Chat with your notes & see links to related content with Local or Remote models.",
-	"minAppVersion": "1.1.0",
-	"authorUrl": "https://github.com/beomsuKoh/obsidian-smart-connections",
-	"isDesktopOnly": true,
-	"version": "3.7.4"
+  "id": "open-connections",
+  "name": "Open Connections",
+  "author": "beomsu koh",
+  "description": "Chat with your notes & see links to related content with Local or Remote models.",
+  "minAppVersion": "1.1.0",
+  "authorUrl": "https://github.com/beomsuKoh/obsidian-smart-connections",
+  "isDesktopOnly": true,
+  "version": "3.7.4"
 }

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -15,6 +15,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   new_user: true,
   re_import_wait_time: 13,
   embed_save_interval: 5,
+  embed_concurrency: 5,
   is_obsidian_vault: true,
 
   smart_sources: {
@@ -34,6 +35,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   smart_blocks: {
     embed_blocks: true,
     min_chars: 200,
+    block_heading_depth: 3,
   },
 
   smart_view_filter: {

--- a/src/domain/entities/BlockCollection.ts
+++ b/src/domain/entities/BlockCollection.ts
@@ -53,11 +53,14 @@ export class BlockCollection extends EntityCollection<EmbeddingBlock> {
       return;
     }
 
+    const max_depth = this.settings.block_heading_depth ?? 3;
+
     // Parse blocks using MetadataCache sections and paragraph splitting
     const blocks = await parse_markdown_blocks(
       content,
       source.key,
       source.cached_metadata,
+      max_depth,
     );
 
     // Create or update block entities
@@ -85,6 +88,14 @@ export class BlockCollection extends EntityCollection<EmbeddingBlock> {
    */
   get_source_blocks(source_key: string): EmbeddingBlock[] {
     return this.all.filter(block => block.source_key === source_key);
+  }
+
+  /**
+   * Get all blocks whose source_key matches the given path.
+   * Preferred alias for get_source_blocks — used by UI layer to avoid inline filter calls.
+   */
+  for_source(path: string): EmbeddingBlock[] {
+    return this.all.filter(block => block.source_key === path);
   }
 
   /**

--- a/src/domain/entities/EmbeddingSource.ts
+++ b/src/domain/entities/EmbeddingSource.ts
@@ -199,6 +199,14 @@ export class EmbeddingSource extends EmbeddingEntity {
   }
 
   /**
+   * Source-level embedding is disabled — blocks only.
+   * Returning false prevents sources from entering the embed queue.
+   */
+  get should_embed(): boolean {
+    return false;
+  }
+
+  /**
    * Get outlinks (from MetadataCache)
    */
   get outlinks(): string[] {

--- a/src/domain/entities/parsers/markdown-splitter.ts
+++ b/src/domain/entities/parsers/markdown-splitter.ts
@@ -23,12 +23,14 @@ interface BlockRange {
  * @param content Markdown content
  * @param source_path Source file path
  * @param metadata MetadataCache metadata (optional)
+ * @param max_depth Maximum heading level to split on (1-6, default 3). Headings deeper than this merge into parent block.
  * @returns Array of block data objects
  */
 export async function parse_markdown_blocks(
   content: string,
   source_path: string,
   metadata?: CachedMetadata,
+  max_depth: number = 3,
 ): Promise<BlockData[]> {
   const lines = content.split('\n');
   const blocks: BlockData[] = [];
@@ -41,8 +43,8 @@ export async function parse_markdown_blocks(
     const paragraph_blocks = await split_by_paragraphs(content, source_path, lines);
     blocks.push(...paragraph_blocks);
   } else {
-    // Split by headings
-    const heading_blocks = await split_by_headings(content, source_path, lines, headings);
+    // Split by headings up to max_depth
+    const heading_blocks = await split_by_headings(content, source_path, lines, headings, max_depth);
     blocks.push(...heading_blocks);
   }
 
@@ -57,11 +59,12 @@ async function split_by_headings(
   source_path: string,
   lines: string[],
   headings: HeadingCache[],
+  max_depth: number,
 ): Promise<BlockData[]> {
   const blocks: BlockData[] = [];
 
   // Build heading hierarchy
-  const heading_ranges = build_heading_ranges(headings, lines.length);
+  const heading_ranges = build_heading_ranges(headings, lines.length, max_depth);
 
   // Create blocks for each heading range
   for (const range of heading_ranges) {
@@ -107,31 +110,39 @@ async function split_by_headings(
 /**
  * Build heading ranges with hierarchy
  * Preserves #heading1#heading2 format for block keys
+ * Headings deeper than max_depth are merged into their parent block's range.
  */
-function build_heading_ranges(headings: HeadingCache[], total_lines: number): BlockRange[] {
+function build_heading_ranges(headings: HeadingCache[], total_lines: number, max_depth: number): BlockRange[] {
   const ranges: BlockRange[] = [];
 
-  // Stack to track current heading path
+  // Stack to track current heading path (all levels, including deep ones)
   const heading_stack: Array<{ heading: string; level: number }> = [];
 
   for (let i = 0; i < headings.length; i++) {
     const current = headings[i];
-    const next = headings[i + 1];
 
     // Update heading stack based on level
     while (heading_stack.length > 0 && heading_stack[heading_stack.length - 1].level >= current.level) {
       heading_stack.pop();
     }
-
-    // Add current heading to stack
     heading_stack.push({ heading: current.heading, level: current.level });
 
-    // Build heading path for key
-    const heading_path = heading_stack.map(h => h.heading);
-    const key = heading_path.map(h => `#${h}`).join('');
+    if (current.level > max_depth) continue;
 
-    // Determine end line
-    const end_line = next ? next.position.start.line - 1 : total_lines - 1;
+    // Block ends before the next heading at the same or shallower level
+    let end_line = total_lines - 1;
+    for (let j = i + 1; j < headings.length; j++) {
+      if (headings[j].level <= current.level) {
+        end_line = headings[j].position.start.line - 1;
+        break;
+      }
+    }
+
+    // Build heading path for key (only the stack entries up to max_depth)
+    const heading_path = heading_stack
+      .filter(h => h.level <= max_depth)
+      .map(h => h.heading);
+    const key = heading_path.map(h => `#${h}`).join('');
 
     ranges.push({
       key,

--- a/src/domain/search/embedding-pipeline.ts
+++ b/src/domain/search/embedding-pipeline.ts
@@ -138,15 +138,19 @@ export class EmbeddingPipeline {
       const effective_concurrency = Math.max(1, concurrency);
       let batch_index = 0;
 
-      const process_next_batch = async (): Promise<void> => {
+      interface WorkerCounts { success: number; failed: number; skipped: number; batches: number }
+
+      const process_next_batch = async (): Promise<WorkerCounts> => {
+        const local: WorkerCounts = { success: 0, failed: 0, skipped: 0, batches: 0 };
+
         while (batch_index < batches.length) {
           if (this.should_halt) {
             // Count remaining unprocessed entities as skipped
             for (let i = batch_index; i < batches.length; i++) {
-              this.stats.skipped += batches[i].length;
+              local.skipped += batches[i].length;
             }
             batch_index = batches.length;
-            return;
+            return local;
           }
 
           const current_batch_index = batch_index++;
@@ -159,13 +163,13 @@ export class EmbeddingPipeline {
           // Hash re-verification: skip entities whose content changed since queuing
           const { passed: hash_filtered, skipped_count: hash_skipped } =
             this.filter_by_hash(batch, expected_hashes);
-          this.stats.skipped += hash_skipped;
+          local.skipped += hash_skipped;
 
           const ready = hash_filtered.filter(e => e._embed_input && e._embed_input.length > 0);
           const skipped_in_batch = hash_filtered.filter(e => !ready.includes(e));
 
           if (ready.length === 0) {
-            this.stats.skipped += skipped_in_batch.length;
+            local.skipped += skipped_in_batch.length;
             this.clear_queue_flags(skipped_in_batch);
             entities_processed += batch.length;
             if (on_progress) {
@@ -180,16 +184,16 @@ export class EmbeddingPipeline {
 
           try {
             const { succeeded, failed_count } = await this.process_batch(ready, max_retries);
-            this.stats.success += succeeded;
-            this.stats.failed += failed_count;
-            this.stats.skipped += skipped_in_batch.length;
+            local.success += succeeded;
+            local.failed += failed_count;
+            local.skipped += skipped_in_batch.length;
             this.clear_queue_flags(skipped_in_batch);
 
             if (on_batch_complete) {
               on_batch_complete(batch_num, ready.length);
             }
           } catch (error) {
-            this.stats.failed += batch.length;
+            local.failed += batch.length;
             this.clear_queue_flags(batch);
 
             if (halt_on_error) {
@@ -207,20 +211,28 @@ export class EmbeddingPipeline {
           }
 
           // Periodic save
+          local.batches++;
           batches_since_save++;
           if (on_save && batches_since_save >= save_interval) {
             await on_save();
             batches_since_save = 0;
           }
         }
+
+        return local;
       };
 
-      // Launch concurrent workers
-      const workers: Promise<void>[] = [];
+      // Launch concurrent workers and merge counts after all complete
+      const workers: Promise<WorkerCounts>[] = [];
       for (let w = 0; w < effective_concurrency; w++) {
         workers.push(process_next_batch());
       }
-      await Promise.all(workers);
+      const workerResults = await Promise.all(workers);
+      for (const r of workerResults) {
+        this.stats.success += r.success;
+        this.stats.failed += r.failed;
+        this.stats.skipped += r.skipped;
+      }
 
       // Final save
       if (on_save && batches_since_save > 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   Plugin,
   TFile,
 } from 'obsidian';
+import { average_vectors } from './utils';
 
 import type { PluginSettings } from './types/settings';
 import { DEFAULT_SETTINGS } from './domain/config';
@@ -220,7 +221,7 @@ export default class SmartConnectionsPlugin extends Plugin {
       ConnectionsView.open(this.app.workspace);
     });
     this.registerMarkdownCodeBlockProcessor('smart-connections', async (source, el) => {
-      if (!this.source_collection) {
+      if (!this.block_collection) {
         el.createEl('p', { text: 'Open Connections is loading...', cls: 'osc-state-text' });
         return;
       }
@@ -236,28 +237,46 @@ export default class SmartConnectionsPlugin extends Plugin {
       const activeFile = this.app.workspace.getActiveFile();
       if (!activeFile) return;
 
-      const entity = this.source_collection.get(activeFile.path);
-      if (!entity?.vec) {
+      // Find embedded blocks for this file and average their vectors
+      const fileBlocks = this.block_collection.all.filter(
+        (b: any) => b.source_key === activeFile.path && b.vec,
+      );
+      if (fileBlocks.length === 0) {
         el.createEl('p', { text: 'No embedding available for this note.', cls: 'osc-state-text' });
         return;
       }
 
+      const avgVec = average_vectors(fileBlocks.map((b: any) => b.vec));
+
       try {
-        const results = await this.source_collection.nearest_to(entity, { limit });
-        const list = el.createEl('ul', { cls: 'osc-codeblock-results' });
+        const blockKeys = new Set(fileBlocks.map((b: any) => b.key));
+        const results = await this.block_collection.nearest(avgVec, { limit: limit * 3, exclude: blockKeys });
+        // Dedupe by source path, keep highest score
+        const seen = new Map<string, { score: number; path: string; heading: string }>();
         for (const r of results) {
-          const score = Math.round((r.score ?? 0) * 100);
-          const path = (r.item?.path ?? '').replace(/\.md$/, '');
+          const key = r.item?.key ?? '';
+          const sourcePath = key.split('#')[0];
+          const heading = key.includes('#') ? key.split('#').pop() ?? '' : '';
+          const score = r.score ?? 0;
+          if (!seen.has(sourcePath) || score > (seen.get(sourcePath)?.score ?? 0)) {
+            seen.set(sourcePath, { score, path: sourcePath, heading });
+          }
+        }
+        const deduped = [...seen.values()].slice(0, limit);
+        const list = el.createEl('ul', { cls: 'osc-codeblock-results' });
+        for (const r of deduped) {
+          const score = Math.round(r.score * 100);
+          const displayPath = r.path.replace(/\.md$/, '');
           const li = list.createEl('li');
           const link = li.createEl('a', {
-            text: path.split('/').pop() ?? path,
+            text: displayPath.split('/').pop() ?? displayPath,
             cls: 'internal-link',
-            attr: { 'data-href': path },
+            attr: { 'data-href': displayPath },
           });
           li.createSpan({ text: ` (${score}%)`, cls: 'osc-score--medium' });
           link.addEventListener('click', (e) => {
             e.preventDefault();
-            this.open_note(r.item?.path ?? '');
+            this.open_note(r.path);
           });
         }
       } catch (_e) {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -100,6 +100,9 @@ export interface BlockSettings {
 
   /** Minimum characters for a block to be embedded */
   min_chars: number;
+
+  /** Maximum heading level to split blocks at (1-6). H1..H<depth> create new blocks; deeper headings merge into parent. */
+  block_heading_depth: number;
 }
 
 /**
@@ -142,6 +145,9 @@ export interface PluginSettings {
 
   /** How often to save embedding progress (in batches). Lower = safer on crash, higher = less I/O */
   embed_save_interval: number;
+
+  /** Number of batches sent to the API simultaneously (1-10, default 5) */
+  embed_concurrency: number;
 
   /** Whether this is an Obsidian vault */
   is_obsidian_vault: boolean;

--- a/src/ui/ConnectionsView.ts
+++ b/src/ui/ConnectionsView.ts
@@ -7,7 +7,10 @@ import {
   setIcon,
 } from 'obsidian';
 import type SmartConnectionsPlugin from '../main';
+import type { ConnectionResult } from '../types/entities';
+import type { EmbeddingBlock } from '../domain/entities/EmbeddingBlock';
 import { showResultContextMenu } from './result-context-menu';
+import { getBlockConnections } from './block-connections';
 
 export const CONNECTIONS_VIEW_TYPE = 'smart-connections-view';
 
@@ -128,7 +131,7 @@ export class ConnectionsView extends ItemView {
 
     this.lastRenderedPath = targetPath;
 
-    if (!this.plugin.ready || !this.plugin.source_collection) {
+    if (!this.plugin.ready || !this.plugin.block_collection) {
       this.showLoading('Smart Connections is initializing...');
       return;
     }
@@ -138,72 +141,66 @@ export class ConnectionsView extends ItemView {
       return;
     }
 
-    const source = this.plugin.source_collection.get(targetPath);
-
-    if (!source) {
-      if (!this.plugin.embed_ready) {
-        this.showLoading(
-          'Smart Connections is loading... Connections will appear when embedding is complete.',
-        );
-      } else {
-        this.showEmpty('Source not found. Check exclusion settings.');
-      }
-      return;
-    }
-
-    const is_source_stale = !!source.is_unembedded;
-    const has_vec = !!source.vec;
-
-    // Try to show results (even if stale — old vectors still produce useful connections)
-    if (has_vec) {
-      try {
-        const results = this.plugin.source_collection.nearest_to
-          ? await this.plugin.source_collection.nearest_to(source, {})
-          : [];
-        this.renderResults(targetPath, results);
-      } catch (e) {
-        this.showError('Failed to find connections: ' + (e as Error).message);
-        return;
-      }
-
-      // If stale, show banner and auto-queue re-embedding
-      if (is_source_stale) {
-        this.addBanner('Re-embedding in progress. Results may be from a previous model.');
-        this.autoQueueEmbedding(source);
-      }
-      return;
-    }
-
-    // No vector at all — auto-queue and show appropriate state
-    if (is_source_stale) {
-      this.autoQueueEmbedding(source);
-      this.showLoading('Embedding this note... Results will appear when ready.');
-    } else if (!this.plugin.embed_ready) {
+    if (!this.plugin.embed_ready) {
       this.showLoading(
         'Smart Connections is loading... Connections will appear when embedding is complete.',
       );
-    } else {
-      this.showEmpty('No embedding available. The note may be too short or excluded.');
+      return;
+    }
+
+    // Find blocks belonging to this file
+    const allFileBlocks = this.plugin.block_collection.for_source(targetPath);
+    const embedded = allFileBlocks.filter(b => b.vec);
+
+    if (embedded.length === 0) {
+      if (allFileBlocks.length > 0) {
+        // Blocks exist but not yet embedded
+        this.autoQueueBlockEmbedding(allFileBlocks);
+        this.showLoading('Embedding this note... Results will appear when ready.');
+      } else {
+        this.showEmpty('No blocks found. The note may be too short or excluded.');
+      }
+      return;
+    }
+
+    try {
+      const results = await getBlockConnections(this.plugin.block_collection, targetPath, { limit: 50 });
+      this.renderResults(targetPath, results);
+    } catch (e) {
+      this.showError('Failed to find connections: ' + (e as Error).message);
     }
   }
 
   /**
-   * Auto-queue the given source for re-embedding without waiting.
+   * Queue a list of blocks for embedding via the job queue.
+   */
+  private enqueueBlocksForEmbedding(blocks: EmbeddingBlock[]): void {
+    const now = Date.now();
+    for (const block of blocks) {
+      block.queue_embed();
+      if (!block._queue_embed) continue;
+      this.plugin.embed_job_queue?.enqueue({
+        entityKey: block.key,
+        contentHash: block.read_hash || '',
+        sourcePath: block.source_key,
+        enqueuedAt: now,
+      });
+    }
+  }
+
+  /**
+   * Auto-queue unembedded blocks for a file.
    * Fire-and-forget — the view will auto-refresh on RUN_FINISHED.
    */
-  private autoQueueEmbedding(source: any): void {
+  private autoQueueBlockEmbedding(blocks: EmbeddingBlock[]): void {
     if (!this.plugin.embed_ready) return;
-    if (this.autoEmbedRequestedForPath === source.key) return;
-    this.autoEmbedRequestedForPath = source.key;
+    const firstKey = blocks[0]?.key;
+    if (!firstKey) return;
+    if (this.autoEmbedRequestedForPath === firstKey.split('#')[0]) return;
+    this.autoEmbedRequestedForPath = firstKey.split('#')[0];
     try {
-      source.queue_embed();
-      this.plugin.embed_job_queue?.enqueue({
-        entityKey: source.key,
-        contentHash: source.read_hash || '',
-        sourcePath: source.key.split('#')[0],
-        enqueuedAt: Date.now(),
-      });
-      void this.plugin.runEmbeddingJob('Auto re-embed for connections view');
+      this.enqueueBlocksForEmbedding(blocks);
+      void this.plugin.runEmbeddingJob('Auto embed blocks for connections view');
     } catch {
       // Non-critical — embedding will happen via normal pipeline eventually
     }
@@ -298,8 +295,8 @@ export class ConnectionsView extends ItemView {
       // Get unique top-level folders from results
       const folders = new Set<string>();
       for (const r of results || []) {
-        const path = r.item?.path ?? '';
-        const parts = path.split('/');
+        const sourcePath = (r.item as EmbeddingBlock).source_key ?? r.item.key.split('#')[0] ?? '';
+        const parts = sourcePath.split('/');
         if (parts.length > 1) folders.add(parts[0]);
       }
       for (const folder of Array.from(folders).sort()) {
@@ -325,15 +322,9 @@ export class ConnectionsView extends ItemView {
 
     this.registerDomEvent(refreshBtn, 'click', async () => {
       try {
-        const source = this.plugin.source_collection?.get(targetPath);
-        if (source && !source.vec) {
-          source.queue_embed();
-          this.plugin.embed_job_queue?.enqueue({
-            entityKey: source.key,
-            contentHash: source.read_hash || '',
-            sourcePath: source.key.split('#')[0],
-            enqueuedAt: Date.now(),
-          });
+        const fileBlocks = this.plugin.block_collection?.for_source(targetPath) ?? [];
+        if (fileBlocks.length > 0) {
+          this.enqueueBlocksForEmbedding(fileBlocks);
           await this.plugin.runEmbeddingJob('Connections view refresh');
         }
       } catch (e) {
@@ -342,11 +333,15 @@ export class ConnectionsView extends ItemView {
       void this.renderView(targetPath);
     });
 
+    // Results are block results; extract source path for filtering/pinning
+    // result.item is a block with source_key = file path
+    const getSourcePath = (r: ConnectionResult): string => (r.item as EmbeddingBlock).source_key ?? r.item.key.split('#')[0] ?? '';
+
     // Filter hidden and by folder
     const filtered = (results || []).filter(r => {
-      const key = r.item?.path ?? '';
-      if (this.session.hiddenKeys.includes(key)) return false;
-      if (this.folderFilter && !key.startsWith(this.folderFilter + '/')) return false;
+      const sourcePath = getSourcePath(r);
+      if (this.session.hiddenKeys.includes(sourcePath)) return false;
+      if (this.folderFilter && !sourcePath.startsWith(this.folderFilter + '/')) return false;
       return true;
     });
 
@@ -358,8 +353,8 @@ export class ConnectionsView extends ItemView {
     // Sort: pinned first, then by score
     const pinnedSet = new Set(this.session.pinnedKeys);
     filtered.sort((a, b) => {
-      const aPinned = pinnedSet.has(a.item?.path ?? '') ? 1 : 0;
-      const bPinned = pinnedSet.has(b.item?.path ?? '') ? 1 : 0;
+      const aPinned = pinnedSet.has(getSourcePath(a)) ? 1 : 0;
+      const bPinned = pinnedSet.has(getSourcePath(b)) ? 1 : 0;
       if (aPinned !== bPinned) return bPinned - aPinned;
       return (b.score ?? 0) - (a.score ?? 0);
     });
@@ -368,12 +363,17 @@ export class ConnectionsView extends ItemView {
 
     for (const [idx, result] of filtered.entries()) {
       const score = result.score ?? result.sim ?? 0;
-      const fullPath = result.item?.path ?? '';
-      const parts = fullPath.replace(/\.md$/, '').split('/');
-      const name = parts.pop() ?? 'Unknown';
-      const breadcrumb = parts.length > 0 ? parts.join(' / ') : '';
+      const blockKey: string = (result.item as EmbeddingBlock).key ?? '';
+      const fullPath = getSourcePath(result);
+      const nameParts = fullPath.replace(/\.md$/, '').split('/');
+      const name = nameParts.pop() ?? 'Unknown';
+      const breadcrumb = nameParts.length > 0 ? nameParts.join(' / ') : '';
       const isPinned = pinnedSet.has(fullPath);
       const scorePercent = Math.round(score * 100);
+
+      // Extract last heading from block key for subtitle
+      const blockParts = blockKey.split('#');
+      const lastHeading = blockParts.length > 1 ? blockParts[blockParts.length - 1] : '';
 
       const item = list.createDiv({
         cls: `osc-result-item${isPinned ? ' osc-result-item--pinned' : ''}`,
@@ -392,11 +392,14 @@ export class ConnectionsView extends ItemView {
       else if (score >= 0.7) scoreBadge.addClass('osc-score--medium');
       else scoreBadge.addClass('osc-score--low');
 
-      // Content: title + breadcrumb
+      // Content: title + breadcrumb + heading indicator
       const content = item.createDiv({ cls: 'osc-result-content' });
       content.createSpan({ text: name, cls: 'osc-result-title' });
       if (breadcrumb) {
         content.createSpan({ text: breadcrumb, cls: 'osc-result-breadcrumb' });
+      }
+      if (lastHeading) {
+        content.createSpan({ text: `#${lastHeading}`, cls: 'osc-result-heading' });
       }
 
       // Pin indicator
@@ -405,13 +408,13 @@ export class ConnectionsView extends ItemView {
         setIcon(pinIcon, 'pin');
       }
 
-      this.registerDomEvent(item, 'click', (e) => {
-        this.plugin.open_note(fullPath, e);
+      this.registerDomEvent(item, 'click', async (e) => {
+        await this.openBlockResult(fullPath, lastHeading, e);
       });
 
       this.registerDomEvent(item, 'keydown', (e) => {
         if (e.key === 'Enter') {
-          this.plugin.open_note(fullPath);
+          void this.openBlockResult(fullPath, lastHeading);
         } else if (e.key === 'ArrowDown') {
           e.preventDefault();
           (item.nextElementSibling as HTMLElement)?.focus();
@@ -460,6 +463,15 @@ export class ConnectionsView extends ItemView {
 
     // Show progress banner if embedding is active
     this.updateProgressBanner();
+  }
+
+  private async openBlockResult(sourcePath: string, heading: string, event?: MouseEvent): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(sourcePath);
+    if (!(file instanceof TFile)) return;
+    const leaf = (event?.ctrlKey || event?.metaKey)
+      ? this.app.workspace.getLeaf('tab')
+      : this.app.workspace.getMostRecentLeaf() ?? this.app.workspace.getLeaf(false);
+    await leaf.openFile(file, heading ? { eState: { subpath: `#${heading}` } } : undefined);
   }
 
   showLoading(message = 'Loading...'): void {

--- a/src/ui/block-connections.ts
+++ b/src/ui/block-connections.ts
@@ -1,0 +1,48 @@
+/**
+ * @file block-connections.ts
+ * @description Shared helper: average block vectors → nearest search → dedupe by source path.
+ * Used by ConnectionsView, commands.ts, and main.ts markdown code block processor.
+ */
+
+import type { BlockCollection } from '../domain/entities';
+import type { EmbeddingBlock } from '../domain/entities/EmbeddingBlock';
+import type { ConnectionResult } from '../types/entities';
+import { average_vectors } from '../utils';
+
+/**
+ * Find connections for a file using its embedded blocks.
+ *
+ * 1. Average the vectors of all embedded blocks for `filePath`.
+ * 2. Search for nearest neighbours, excluding all blocks that belong to `filePath`.
+ * 3. Dedupe by source path, keeping the highest-scoring block per file.
+ * 4. Return results sorted descending by score, capped at `limit`.
+ */
+export async function getBlockConnections(
+  blockCollection: BlockCollection,
+  filePath: string,
+  opts?: { limit?: number },
+): Promise<ConnectionResult[]> {
+  const limit = opts?.limit ?? 50;
+  const fileBlocks = blockCollection.for_source(filePath);
+  const embedded = fileBlocks.filter(b => b.vec);
+  if (embedded.length === 0) return [];
+
+  const avgVec = average_vectors(embedded.map(b => b.vec!));
+  const excludeKeys = new Set(fileBlocks.map(b => b.key));
+  const results = await blockCollection.nearest(avgVec, { limit: limit * 3, exclude: excludeKeys });
+
+  // Dedupe by source path, keep highest score
+  const seen = new Map<string, ConnectionResult>();
+  for (const r of results) {
+    const sourcePath = (r.item as EmbeddingBlock).source_key ?? r.item.key.split('#')[0];
+    if (!sourcePath || sourcePath === filePath) continue;
+    const existing = seen.get(sourcePath);
+    if (!existing || (r.score ?? 0) > (existing.score ?? 0)) {
+      seen.set(sourcePath, r);
+    }
+  }
+
+  return [...seen.values()]
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, limit);
+}

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -4,8 +4,11 @@
  */
 
 import type { Plugin } from 'obsidian';
+import type { BlockCollection } from '../domain/entities';
+import type { EmbeddingBlock } from '../domain/entities/EmbeddingBlock';
 import { ConnectionsView } from './ConnectionsView';
 import { LookupView } from './LookupView';
+import { getBlockConnections } from './block-connections';
 
 /**
  * Register all plugin commands
@@ -52,7 +55,7 @@ export function registerCommands(plugin: Plugin): void {
     name: 'Refresh embeddings',
     callback: async () => {
       const p = plugin as any;
-      if (!p.source_collection || !p.embedding_pipeline) return;
+      if (!p.block_collection || !p.embedding_pipeline) return;
       await p.reembedStaleEntities?.('Command: Refresh embeddings');
     },
   });
@@ -73,22 +76,23 @@ export function registerCommands(plugin: Plugin): void {
     callback: async () => {
       const p = plugin as any;
       const activeFile = plugin.app.workspace.getActiveFile();
-      if (!activeFile || !p.source_collection) return;
+      if (!activeFile || !p.block_collection) return;
 
-      const source = p.source_collection.get(activeFile.path);
-      if (!source?.vec) {
+      const blockCollection = p.block_collection as BlockCollection;
+      const hasEmbedded = blockCollection.for_source(activeFile.path).some((b: EmbeddingBlock) => b.vec);
+      if (!hasEmbedded) {
         p.notices?.show('no_embedding_for_context');
         return;
       }
 
       try {
-        const results = await p.source_collection.nearest_to(source, { limit: 20 });
+        const results = await getBlockConnections(blockCollection, activeFile.path, { limit: 20 });
         if (!results || results.length === 0) return;
 
-        const lines = results.map((r: any) => {
+        const lines = results.map(r => {
           const score = Math.round((r.score ?? 0) * 100);
-          const path = (r.item?.path ?? '').replace(/\.md$/, '');
-          return `- [[${path}]] (${score}%)`;
+          const sourcePath = ((r.item as EmbeddingBlock).source_key ?? '').replace(/\.md$/, '');
+          return `- [[${sourcePath}]] (${score}%)`;
         });
 
         const contextText = `## Smart Context: ${activeFile.basename}\n\n${lines.join('\n')}`;
@@ -107,17 +111,17 @@ export function registerCommands(plugin: Plugin): void {
     callback: async () => {
       const p = plugin as any;
       const activeFile = plugin.app.workspace.getActiveFile();
-      if (!activeFile || !p.source_collection) return;
+      if (!activeFile || !p.block_collection) return;
 
-      const source = p.source_collection.get(activeFile.path);
-      if (!source?.vec) return;
+      const blockCollection = p.block_collection as BlockCollection;
+      if (!blockCollection.for_source(activeFile.path).some((b: EmbeddingBlock) => b.vec)) return;
 
       try {
-        const results = await p.source_collection.nearest_to(source, { limit: 20 });
+        const results = await getBlockConnections(blockCollection, activeFile.path, { limit: 20 });
         if (!results || results.length === 0) return;
 
         const randomIdx = Math.floor(Math.random() * results.length);
-        const randomPath = results[randomIdx].item?.path;
+        const randomPath = (results[randomIdx].item as EmbeddingBlock).source_key;
         if (randomPath) p.open_note(randomPath);
       } catch (e) {
         console.error('Failed to find random connection:', e);

--- a/src/ui/embedding/collection-loader.ts
+++ b/src/ui/embedding/collection-loader.ts
@@ -97,11 +97,8 @@ export function queueUnembeddedEntities(plugin: SmartConnectionsPlugin): number 
     queued++;
   };
 
-  if (plugin.source_collection) {
-    for (const source of plugin.source_collection.all) {
-      enqueueEntity(source);
-    }
-  }
+  // Source-level embedding is disabled — blocks only.
+  // Sources return should_embed=false so skipping them avoids unnecessary iteration.
   if (plugin.block_collection) {
     for (const block of plugin.block_collection.all) {
       enqueueEntity(block);

--- a/src/ui/embedding/embed-orchestrator.ts
+++ b/src/ui/embedding/embed-orchestrator.ts
@@ -772,6 +772,7 @@ async function runEmbeddingJobNow(plugin: SmartConnectionsPlugin, reason: string
     const stats = await plugin.embedding_pipeline.process(entitiesToEmbed, {
       batch_size: 10,
       max_retries: 3,
+      concurrency: plugin.settings.embed_concurrency || 5,
       on_progress: createProgressCallback(plugin, runId, ctx),
       on_save: createSaveCallback(plugin, runId, ctx),
       save_interval: plugin.settings.embed_save_interval || 5,

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -317,6 +317,19 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
+      .setName('Block heading depth')
+      .setDesc('Split blocks at heading levels up to this depth (1=H1 only, 6=all headings). H4+ headings merge into their parent block at the default of 3.')
+      .addSlider((slider) => {
+        slider
+          .setLimits(1, 6, 1)
+          .setValue(this.getConfig('smart_blocks.block_heading_depth', 3))
+          .setDynamicTooltip()
+          .onChange(async (value) => {
+            this.setConfig('smart_blocks.block_heading_depth', value);
+          });
+      });
+
+    new Setting(containerEl)
       .setName('Save frequency')
       .setDesc('Save progress every N batches. Lower = safer on crash, higher = less disk I/O')
       .addSlider((slider) => {
@@ -326,6 +339,19 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
           .setDynamicTooltip()
           .onChange(async (value) => {
             this.setConfig('embed_save_interval', value);
+          });
+      });
+
+    new Setting(containerEl)
+      .setName('Embedding concurrency')
+      .setDesc('Number of batches sent to the API simultaneously. Lower if hitting rate limits.')
+      .addSlider((slider) => {
+        slider
+          .setLimits(1, 10, 1)
+          .setValue(this.getConfig('embed_concurrency', 5))
+          .setDynamicTooltip()
+          .onChange(async (value) => {
+            this.setConfig('embed_concurrency', value);
           });
       });
   }

--- a/src/utils/average_vectors.ts
+++ b/src/utils/average_vectors.ts
@@ -1,0 +1,19 @@
+/**
+ * @file average_vectors.ts
+ * @description Computes the element-wise average of a set of vectors.
+ */
+
+/**
+ * Compute the element-wise average of one or more vectors.
+ * Returns an empty array when no vectors are provided.
+ */
+export function average_vectors(vecs: number[][]): number[] {
+  if (vecs.length === 0) return [];
+  const dims = vecs[0].length;
+  const out = new Array<number>(dims).fill(0);
+  for (const v of vecs) {
+    for (let i = 0; i < dims; i++) out[i] += v[i];
+  }
+  for (let i = 0; i < dims; i++) out[i] /= vecs.length;
+  return out;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,6 +5,7 @@
 
 export { cos_sim } from './cos_sim';
 export { create_hash } from './create_hash';
+export { average_vectors } from './average_vectors';
 export {
   results_acc,
   furthest_acc,

--- a/test/connections-view-session.test.ts
+++ b/test/connections-view-session.test.ts
@@ -27,13 +27,15 @@ function createPluginStub() {
     },
     source_collection: {
       size: 2,
-      all: [{ vec: [1, 2, 3] }, { vec: null }],
+      all: [],
       data_dir: '/tmp/sources',
       get: vi.fn(() => null),
-      nearest_to: vi.fn(async () => []),
     },
     block_collection: {
       data_dir: '/tmp/blocks',
+      all: [] as any[],
+      for_source(path: string) { return (this.all as any[]).filter((b: any) => b.source_key === path); },
+      nearest: vi.fn(async () => []),
     },
     open_note: vi.fn(),
     embed_job_queue: null,
@@ -94,51 +96,51 @@ function createObsidianLikeContainer(): any {
 }
 
 describe('ConnectionsView rendering states', () => {
-  it('shows cached results with banner when source is stale but has vec', async () => {
+  it('calls block_collection.nearest when blocks with vectors exist for the active file', async () => {
     const plugin = createPluginStub();
     plugin.status_state = 'idle';
-    const staleSource = {
-      key: 'note.md',
+    const embeddedBlock = {
+      key: 'note.md#Section',
+      source_key: 'note.md',
       vec: [1, 2, 3],
-      is_unembedded: true,
+      is_unembedded: false,
     };
-    plugin.source_collection.get = vi.fn(() => staleSource);
-    plugin.source_collection.nearest_to = vi.fn(async () => [{ item: { path: 'other.md' }, score: 0.9 }]);
-    plugin.embed_job_queue = { enqueue: vi.fn() };
-    plugin.runEmbeddingJob = vi.fn(async () => ({}));
+    plugin.block_collection.all = [embeddedBlock];
+    plugin.block_collection.nearest = vi.fn(async () => [
+      { item: { key: 'other.md#Topic', source_key: 'other.md' }, score: 0.9 },
+    ]);
 
     const view = new ConnectionsView({} as any, plugin);
     (view as any).container = createObsidianLikeContainer();
 
     await view.renderView('note.md');
 
-    // Should show results (nearest_to was called) instead of empty/loading
-    expect(plugin.source_collection.nearest_to).toHaveBeenCalled();
+    // Should search blocks and render results
+    expect(plugin.block_collection.nearest).toHaveBeenCalled();
   });
 
-  it('shows cached results with banner when source is stale and queue is active', async () => {
+  it('shows loading state when blocks exist but have no vectors yet', async () => {
     const plugin = createPluginStub();
-    const staleSource = {
-      key: 'note.md',
-      vec: [1, 2, 3],
+    const unembeddedBlock = {
+      key: 'note.md#Section',
+      source_key: 'note.md',
+      vec: null,
       is_unembedded: true,
+      queue_embed: vi.fn(),
+      _queue_embed: false,
     };
-    plugin.source_collection.get = vi.fn(() => staleSource);
-    plugin.source_collection.nearest_to = vi.fn(async () => [{ item: { path: 'other.md' }, score: 0.9 }]);
+    plugin.block_collection.all = [unembeddedBlock];
     plugin.embed_job_queue = { enqueue: vi.fn() };
     plugin.runEmbeddingJob = vi.fn(async () => ({}));
-    plugin.getEmbeddingKernelState = vi.fn(() => ({
-      phase: 'idle',
-      queue: { queuedTotal: 1 },
-    }));
 
     const view = new ConnectionsView({} as any, plugin);
     (view as any).container = createObsidianLikeContainer();
 
     await view.renderView('note.md');
 
-    // Should show results instead of loading spinner
-    expect(plugin.source_collection.nearest_to).toHaveBeenCalled();
+    // Should show loading state (no embedded blocks to search with)
+    const text = (view as any).container.textContent;
+    expect(text).toContain('Embedding');
   });
 
   it('refresh button triggers re-embed from loading state', async () => {


### PR DESCRIPTION
## Summary

- **Block-only search**: All search uses heading-level block embeddings instead of truncated source embeddings. Results show `#heading` on second line, click navigates to heading.
- **Source embedding disabled**: `EmbeddingSource.should_embed = false` — sources are metadata-only, blocks are the embedding unit.
- **Configurable heading depth**: Settings slider (1-6, default H3) controls how deep heading splitting goes.
- **Parallel pipeline**: Settings slider (1-10, default 5) sends N batches concurrently for ~5x throughput.
- **Shared utilities**: `average_vectors()`, `getBlockConnections()`, `BlockCollection.for_source()`, deduplicated enqueue helper.
- **Pipeline stats race fix**: Worker-local accumulation prevents lost increments under concurrency.

## Breaking changes

- Connections View now shows block-level results instead of note-level
- Existing source embeddings become orphan data (ignored, not deleted)
- First startup after update triggers full block embedding

## Test plan

- [x] CI passes (233 tests)
- [ ] Test vault: Connections View shows block results with headings
- [ ] LookupView search returns block-level results
- [ ] Click result → navigates to heading
- [ ] Heading depth slider: change → blocks regenerate
- [ ] Concurrency slider: change → batches sent in parallel
- [ ] Note edit → only changed block re-embeds

🤖 Generated with [Claude Code](https://claude.ai/code)