### PR TITLE
fix: eliminate startup freeze — deferred discovery + correctness fixes

### DIFF
--- a/src/domain/entities/BlockCollection.ts
+++ b/src/domain/entities/BlockCollection.ts
@@ -63,12 +63,11 @@ export class BlockCollection extends EntityCollection<EmbeddingBlock> {
       max_depth,
     );
 
-    // Create or update block entities
+    // Create or update block entities — strip embeddings so Object.assign in
+    // create_or_update does not overwrite vectors loaded from the DB with {}
     for (const block_data of blocks) {
-      this.create_or_update(block_data);
-
-      // Store block reference in source
-      // (Not storing in source.data.blocks to avoid circular dependency)
+      const { embeddings: _, ...update_data } = block_data;
+      this.create_or_update(update_data);
     }
 
     // Clean up removed blocks

--- a/src/domain/entities/SourceCollection.ts
+++ b/src/domain/entities/SourceCollection.ts
@@ -22,6 +22,9 @@ export class SourceCollection extends EntityCollection<EmbeddingSource> {
   /** Block collection reference */
   block_collection?: any;
 
+  /** True during initial vault discovery — blocks loaded from DB, not parsed from files */
+  _initializing = true;
+
   constructor(
     data_dir: string,
     settings: any = {},
@@ -44,15 +47,10 @@ export class SourceCollection extends EntityCollection<EmbeddingSource> {
 
   /**
    * Initialize collection
-   * Discover files from vault
+   * DB load happens in loadCollections(); discovery happens after via discoverNewSources()
    */
   async init(): Promise<void> {
     await super.init();
-
-    // Discover files if vault is available
-    if (this.vault) {
-      await this.discover_sources();
-    }
   }
 
   /**
@@ -100,8 +98,9 @@ export class SourceCollection extends EntityCollection<EmbeddingSource> {
       }
     }
 
-    // Import blocks if enabled (embed_blocks lives in block_collection's settings)
-    if (this.block_collection?.settings?.embed_blocks) {
+    // Skip block import during initial discovery — blocks are loaded from SQLite.
+    // Only parse blocks on file change (re-import after vault events).
+    if (!this._initializing && this.block_collection?.settings?.embed_blocks) {
       await this.block_collection.import_source_blocks(source);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ import {
 import {
   initCollections as _initCollections,
   loadCollections as _loadCollections,
+  discoverNewSources as _discoverNewSources,
   queueUnembeddedEntities as _queueUnembeddedEntities,
   getEmbeddingQueueSnapshot as _getEmbeddingQueueSnapshot,
   syncCollectionEmbeddingContext as _syncCollectionEmbeddingContext,
@@ -309,8 +310,11 @@ export default class SmartConnectionsPlugin extends Plugin {
     const phase1Start = performance.now();
     console.log('[SC][Init] ▶ Phase 1: Core initialization starting');
 
-    const TOTAL = 6;
+    const TOTAL = 5;
     let step = 0;
+
+    // Setup status bar first so users see feedback during the rest of init
+    this.setupStatusBar();
 
     /**
      * Run an init step with timing and error capture.
@@ -356,11 +360,11 @@ export default class SmartConnectionsPlugin extends Plugin {
       },
     })) return;
 
-    await runStep('Setting up status bar', () => this.setupStatusBar());
     await runStep('Registering file watchers', () => this.registerFileWatchers());
 
     this.ready = true;
     this.dispatchKernelEvent({ type: 'INIT_CORE_READY' });
+    this.app.workspace.trigger('smart-connections:core-ready' as any);
     console.log(`[SC][Init] ✓ Phase 1 complete (${(performance.now() - phase1Start).toFixed(0)}ms) — ready=${this.ready}, errors=${this.init_errors.length}`);
 
     if (this.init_errors.length > 0) {
@@ -378,6 +382,7 @@ export default class SmartConnectionsPlugin extends Plugin {
     } catch { /* use default 'unknown' */ }
     console.log(`[SC][Init] ▶ Phase 2: Embedding initialization starting (model: ${modelId})`);
     try {
+      await this.discoverNewSources();
       await this.switchEmbeddingModel('Initial embedding setup');
       console.log(`[SC][Init] ✓ Phase 2 complete (${(performance.now() - t0).toFixed(0)}ms)`);
     } catch (e) {
@@ -494,14 +499,13 @@ export default class SmartConnectionsPlugin extends Plugin {
   isNewUser(): boolean { return _isNewUser(this); }
 
   async waitForSync(): Promise<void> {
-    // Wait 3 seconds for other processes to finish
-    await new Promise((r) => setTimeout(r, 3000));
-
-    // Wait for Obsidian Sync if active
+    if (!this.obsidianIsSyncing()) return;
+    console.log('[SC][Init] Waiting for Obsidian Sync to finish...');
+    await new Promise(r => setTimeout(r, 1000));
     while (this.obsidianIsSyncing()) {
-      console.log('Open Connections: Waiting for Obsidian Sync to finish');
-      await new Promise((r) => setTimeout(r, 1000));
+      await new Promise(r => setTimeout(r, 1000));
     }
+    console.log('[SC][Init] Obsidian Sync complete');
   }
 
   obsidianIsSyncing(): boolean {
@@ -522,6 +526,7 @@ export default class SmartConnectionsPlugin extends Plugin {
 
   async initCollections(): Promise<void> { return _initCollections(this); }
   async loadCollections(): Promise<void> { return _loadCollections(this); }
+  async discoverNewSources(): Promise<void> { return _discoverNewSources(this); }
 
   async initPipeline(): Promise<void> { return _initPipeline(this); }
   async runEmbeddingJob(reason: string = 'Embedding run'): Promise<EmbedQueueStats | null> { return _runEmbeddingJob(this, reason); }

--- a/src/ui/ConnectionsView.ts
+++ b/src/ui/ConnectionsView.ts
@@ -85,6 +85,13 @@ export class ConnectionsView extends ItemView {
     );
 
     this.registerEvent(
+      this.app.workspace.on('smart-connections:core-ready' as any, () => {
+        const file = this.app.workspace.getActiveFile();
+        if (file) void this.renderView(file.path);
+      }),
+    );
+
+    this.registerEvent(
       this.app.workspace.on('smart-connections:embed-ready' as any, () => {
         void this.renderView();
       }),

--- a/src/ui/embedding/collection-loader.ts
+++ b/src/ui/embedding/collection-loader.ts
@@ -62,19 +62,36 @@ export async function loadCollections(plugin: SmartConnectionsPlugin): Promise<v
       throw new Error('Collections must be initialized before loading');
     }
 
-    let t = performance.now();
-    await plugin.source_collection.data_adapter.load();
+    const t = performance.now();
+    await Promise.all([
+      plugin.source_collection.data_adapter.load(),
+      plugin.block_collection.data_adapter.load(),
+    ]);
     plugin.source_collection.loaded = true;
-    console.log(`[SC][Init]   [collections] Loading sources ✓ (${(performance.now() - t).toFixed(0)}ms)`);
-
-    t = performance.now();
-    await plugin.block_collection.data_adapter.load();
     plugin.block_collection.loaded = true;
-    console.log(`[SC][Init]   [collections] Loading blocks ✓ (${(performance.now() - t).toFixed(0)}ms)`);
+    console.log(`[SC][Init]   [collections] Loading sources + blocks ✓ (${(performance.now() - t).toFixed(0)}ms)`);
+
+    plugin.source_collection._initializing = false;
   } catch (error) {
     console.error('[SC][Init]   [collections] Failed to load collections:', error);
     plugin.notices.show('failed_load_collection_data');
     throw error;
+  }
+}
+
+export async function discoverNewSources(plugin: SmartConnectionsPlugin): Promise<void> {
+  if (!plugin.source_collection?.vault) return;
+  const knownPaths = new Set(plugin.source_collection.all.map((s: any) => s.key));
+  const vaultFiles = plugin.app.vault.getMarkdownFiles();
+  let discovered = 0;
+  for (const file of vaultFiles) {
+    if (!knownPaths.has(file.path)) {
+      await plugin.source_collection.import_source(file);
+      discovered++;
+    }
+  }
+  if (discovered > 0) {
+    console.log(`[SC][Init] Discovered ${discovered} new files`);
   }
 }
 


### PR DESCRIPTION
## Summary

Plugin froze Obsidian for 20-70s on 13k vault. Six fixes:

1. **Deferred discovery**: `discover_sources()` moved from Phase 1 (blocking) to Phase 2 (background). Only new files processed.
2. **`_initializing` lifecycle**: Flag now correctly cleared after DB load — block re-import works on file changes.
3. **Block vector preservation**: Strips `embeddings: {}` from block_data on re-import — prevents wiping loaded vectors.
4. **Smart sync wait**: 3-second unconditional sleep removed — only waits if Obsidian Sync is active.
5. **Early status bar + core-ready event**: Status bar appears immediately, ConnectionsView auto-refreshes when Phase 1 completes.
6. **Parallel DB loads**: Source + block SQLite loads run via `Promise.all`.

## Expected performance

| Phase | Before | After |
|-------|--------|-------|
| Phase 1 | 20-70s | < 2s |
| Phase 2 | embedding only | discovery + embedding (background) |

## Test plan

- [x] CI passes (233 tests)
- [ ] Test vault: plugin loads in < 2 seconds
- [ ] ConnectionsView shows results from DB immediately
- [ ] New note → blocks appear after background discovery
- [ ] Edit note → blocks re-imported correctly
- [ ] No 3-second wait without Obsidian Sync

🤖 Generated with [Claude Code](https://claude.ai/code)