### PR TITLE
fix(embed): structural audit fixes — hash coupling, pipeline safety, progress UI

### DIFF
--- a/src/domain/entities/sqlite-data-adapter.ts
+++ b/src/domain/entities/sqlite-data-adapter.ts
@@ -188,8 +188,11 @@ function ensureSchema(db: SqlJsDatabase): void {
       embed_hash TEXT,
       dims INTEGER,
       updated_at INTEGER,
-      PRIMARY KEY (entity_key, model_key),
-      FOREIGN KEY (entity_key) REFERENCES entities(entity_key) ON DELETE CASCADE
+      PRIMARY KEY (entity_key, model_key)
+      -- NOTE: No FOREIGN KEY with ON DELETE CASCADE here. PRAGMA foreign_keys is OFF
+      -- (SQLite default). Enabling it would break INSERT OR REPLACE (which is
+      -- internally DELETE+INSERT), wiping embeddings on every entity upsert.
+      -- Embedding cleanup on entity deletion is handled manually in executeSaveBatch.
     );
     CREATE INDEX IF NOT EXISTS idx_embeddings_model_key ON entity_embeddings(model_key);
   `);
@@ -698,6 +701,9 @@ export class SqliteDataAdapter<T extends EmbeddingEntity> {
       db.run('BEGIN TRANSACTION');
       transactionOpen = true;
 
+      // Manual cascade: delete embeddings first, then entity.
+      // This is the ONLY cleanup mechanism — ON DELETE CASCADE is intentionally off
+      // (see ensureSchema comment). Any new delete path must also delete from both tables.
       for (const key of deletedKeys) {
         db.run('DELETE FROM entity_embeddings WHERE entity_key = ?', [key]);
         db.run('DELETE FROM entities WHERE entity_key = ?', [key]);
@@ -773,9 +779,19 @@ export class SqliteDataAdapter<T extends EmbeddingEntity> {
 
     const embedding = entity.data.embeddings?.[modelKey];
     const vec = embedding?.vec;
-    if (!vec || vec.length === 0) return;
-
     const meta = entity.data.embedding_meta?.[modelKey];
+
+    if (!vec || vec.length === 0) {
+      // Vec is lazy-loaded (stored as [] on load). When a save occurs before the vec is
+      // fetched back into memory, we must still sync embed_hash so the next load's hash
+      // comparison doesn't falsely mark this entity as unembedded.
+      if (!meta) return; // Never been embedded — nothing to preserve.
+      db.run(
+        `UPDATE entity_embeddings SET embed_hash = ?, dims = ?, updated_at = ? WHERE entity_key = ? AND model_key = ?`,
+        [meta.hash ?? null, meta.dims ?? null, meta.updated_at ?? Date.now(), entity.key, modelKey],
+      );
+      return;
+    }
     const embedHash =
       meta?.hash ?? entity.data.last_embed?.hash ?? entity.data.last_read?.hash ?? null;
     const dims = meta?.dims ?? vec.length;

--- a/src/main.ts
+++ b/src/main.ts
@@ -533,8 +533,17 @@ export default class SmartConnectionsPlugin extends Plugin {
   async waitForSync(): Promise<void> {
     if (!this.obsidianIsSyncing()) return;
     console.log('[SC][Init] Waiting for Obsidian Sync to finish...');
+    const deadline = Date.now() + 60_000; // 60s timeout
     await new Promise(r => setTimeout(r, 1000));
     while (this.obsidianIsSyncing()) {
+      if (this._unloading) {
+        console.warn('[SC][Init] Plugin unloading during sync wait, aborting');
+        return;
+      }
+      if (Date.now() > deadline) {
+        console.warn('[SC][Init] Sync wait timed out after 60s, proceeding without sync completion');
+        return;
+      }
       await new Promise(r => setTimeout(r, 1000));
     }
     console.log('[SC][Init] Obsidian Sync complete');
@@ -629,9 +638,20 @@ export default class SmartConnectionsPlugin extends Plugin {
     // Unload environment
     this.env?.unload?.();
 
-    // Start SQLite cleanup immediately so hot reload cannot grab a DB that
-    // the previous plugin instance is still about to close.
+    // Flush pending save queues before closing DBs — ensures deleted files
+    // and in-memory state changes are persisted. All three calls go through
+    // the same queueDbOperation queue, so saves complete before close.
+    const srcAdapter = this.source_collection?.data_adapter;
+    const blkAdapter = this.block_collection?.data_adapter;
+
+    // resetTransientRuntimeState MUST run synchronously so tests and hot-reload
+    // see ready=false immediately after onunload().
     this.resetTransientRuntimeState();
+
+    // Fire-and-forget: saves enqueue into the same DB operation queue as close,
+    // so ordering (save → save → close) is preserved by the queue.
+    if (srcAdapter) srcAdapter.save().catch((e: unknown) => console.warn('[SC] Flush source save failed:', e));
+    if (blkAdapter) blkAdapter.save().catch((e: unknown) => console.warn('[SC] Flush block save failed:', e));
     closeSqliteDatabases().catch((err: unknown) => {
       console.warn('Failed to close SQLite databases:', err);
     });

--- a/src/styles.css
+++ b/src/styles.css
@@ -41,8 +41,8 @@
   color: var(--text-muted);
 }
 
-/* Embedding progress banner */
-.osc-embed-progress {
+/* Embedding progress banner — dual Notes + Blocks bars */
+.osc-embed-dual-progress {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -50,26 +50,27 @@
   background: var(--background-secondary);
   border-bottom: 1px solid var(--background-modifier-border);
 }
-.osc-embed-progress-text {
-  font-size: var(--font-smallest, 11px);
+
+.osc-embed-dual-progress-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.osc-embed-dual-progress-label {
+  font-size: var(--font-ui-small);
   color: var(--text-muted);
+  min-width: 38px;
 }
-.osc-embed-progress-bar {
-  height: 3px;
-  border-radius: 2px;
-  background: var(--background-modifier-border);
-  overflow: hidden;
+
+.osc-embed-dual-progress-row .progress-bar {
+  flex: 1;
 }
-.osc-embed-progress-vault {
+
+.osc-embed-dual-progress-count {
   font-size: var(--font-ui-smaller);
-  color: var(--text-muted);
-  margin-top: 2px;
-}
-.osc-embed-progress-fill {
-  height: 100%;
-  border-radius: 2px;
-  background: var(--interactive-accent);
-  transition: width 0.3s ease;
+  color: var(--text-faint);
+  white-space: nowrap;
 }
 
 .osc-header-title {
@@ -216,7 +217,6 @@
   color: var(--text-faint);
 }
 
-
 /* ─── Notices ─── */
 /* Obsidian's .notice container always uses a dark background regardless of theme.
    Use `color: inherit` to pick up Obsidian's notice text color (light/white)
@@ -302,7 +302,6 @@
   color: var(--text-muted);
 }
 
-
 /* ─── State Displays (Loading/Empty/Error) ─── */
 .osc-state {
   display: flex;
@@ -348,7 +347,6 @@
 @keyframes osc-spin {
   to { transform: rotate(360deg); }
 }
-
 
 /* ─── Advanced (Collapsible) Section ─── */
 .osc-advanced-section {
@@ -500,11 +498,6 @@
 
 .osc-stat--amber .osc-stat-value {
   color: var(--osc-color-warning);
-}
-
-.osc-settings-embed-progress {
-  margin: 0 16px 8px;
-  min-height: 6px;
 }
 
 /* ─── Side Panes ─── */

--- a/src/ui/ConnectionsView.ts
+++ b/src/ui/ConnectionsView.ts
@@ -7,12 +7,11 @@ import {
   setIcon,
 } from 'obsidian';
 import type SmartConnectionsPlugin from '../main';
-import type { EmbedProgressEventPayload } from '../main';
 import type { ConnectionResult } from '../types/entities';
 import type { EmbeddingBlock } from '../domain/entities/EmbeddingBlock';
 import { showResultContextMenu } from './result-context-menu';
 import { getBlockConnections, invalidateConnectionsCache } from './block-connections';
-import { formatEta } from '../utils';
+import { renderEmbedProgress } from './embed-progress';
 
 export const CONNECTIONS_VIEW_TYPE = 'open-connections-view';
 
@@ -46,7 +45,7 @@ export class ConnectionsView extends ItemView {
   container: HTMLElement;
   private session: ConnectionsSessionState = { pinnedKeys: [], hiddenKeys: [], paused: false };
   private folderFilter: string = '';
-  private progressEl: HTMLElement | null = null;
+  private embedProgress: ReturnType<typeof renderEmbedProgress> | null = null;
   private lastRenderedPath: string | null = null;
   private autoEmbedRequestedForPath: string | null = null;
   private _autoEmbedTimeout: number | null = null;
@@ -115,6 +114,12 @@ export class ConnectionsView extends ItemView {
     );
 
     this.registerEvent(
+      (this.app.workspace as any).on('open-connections:model-switched', () => {
+        this.handleModelSwitched();
+      }),
+    );
+
+    this.registerEvent(
       this.app.workspace.on('open-connections:embed-state-changed' as any, (payload: any) => {
         this.updateProgressBanner();
         // Auto-refresh when embedding finishes (running → idle) and we have a stale view
@@ -129,8 +134,8 @@ export class ConnectionsView extends ItemView {
 
     // Live progress updates from the embedding pipeline (fires ~1/sec)
     this.registerEvent(
-      this.app.workspace.on('open-connections:embed-progress' as any, (payload?: EmbedProgressEventPayload) => {
-        this.updateProgressBanner(payload);
+      this.app.workspace.on('open-connections:embed-progress' as any, () => {
+        this.updateProgressBanner();
       }),
     );
 
@@ -152,7 +157,15 @@ export class ConnectionsView extends ItemView {
 
   async onClose(): Promise<void> {
     this.clearAutoEmbedTimeout();
+    this.clearEmbedProgress();
     this.container?.empty();
+  }
+
+  private clearEmbedProgress(): void {
+    if (this.embedProgress) {
+      this.embedProgress.destroy();
+      this.embedProgress = null;
+    }
   }
 
   private async deriveViewState(targetPath: string): Promise<ViewState> {
@@ -242,9 +255,11 @@ export class ConnectionsView extends ItemView {
       const state = await this.deriveViewState(targetPath);
       if (gen !== this._renderGen) return;
       this.applyViewState(state);
+      this.updateProgressBanner();
     } catch (e) {
       if (gen !== this._renderGen) return;
       this.showError('Failed to find connections: ' + (e as Error).message);
+      this.updateProgressBanner();
     }
   }
 
@@ -298,53 +313,39 @@ export class ConnectionsView extends ItemView {
     banner.createSpan({ text: message, cls: 'osc-banner-text' });
   }
 
-  private updateProgressBanner(payload?: EmbedProgressEventPayload): void {
-    if (!this.container) return;
-    const ctx = this.plugin.current_embed_context;
-    const isRunning = this.plugin.status_state === 'embedding' && ctx;
+  private handleModelSwitched(): void {
+    this.clearAutoEmbedTimeout();
+    this.clearEmbedProgress();
+    invalidateConnectionsCache();
+    this.container.empty();
+    this.addBanner('Embedding model changed. Re-embedding in progress.');
+    this.lastRenderedPath = null;
+    this._lastResultKeys = [];
+    this.autoEmbedRequestedForPath = null;
+  }
 
-    if (!isRunning) {
-      if (this.progressEl) {
-        this.progressEl.remove();
-        this.progressEl = null;
+  private updateProgressBanner(): void {
+    if (!this.container) return;
+
+    // Show progress whenever embedding is incomplete; hide only at 100%
+    const blocksAll = this.plugin.block_collection?.all;
+    const totalBlocks = blocksAll?.length ?? 0;
+    const embeddedBlocks = totalBlocks > 0 ? blocksAll.filter((b: any) => b.vec).length : 0;
+    const isComplete = totalBlocks > 0 && embeddedBlocks >= totalBlocks;
+
+    if (isComplete || totalBlocks === 0) {
+      if (this.embedProgress) {
+        this.embedProgress.destroy();
+        this.embedProgress = null;
       }
       return;
     }
 
-    // Run progress from payload (primary); fall back to ctx
-    const runCurrent = payload?.current ?? ctx.current;
-    const runTotal = payload?.total ?? ctx.total;
-    const runPercent = payload?.percent ?? (runTotal > 0 ? Math.round((runCurrent / runTotal) * 100) : 0);
-    const etaMs = payload?.etaMs ?? null;
-    const etaStr = formatEta(etaMs);
-    const etaPart = etaStr ? ` ETA: ${etaStr}` : '';
-    const runText = `Embedding: ${runCurrent.toLocaleString()}/${runTotal.toLocaleString()} (${runPercent}%)${etaPart}`;
-
-    // Vault-wide progress (secondary, muted)
-    const blocks = this.plugin.block_collection?.all;
-    const totalBlocks = blocks?.length ?? 0;
-    const embeddedBlocks = blocks?.filter((b: any) => b.vec)?.length ?? 0;
-    const vaultPercent = totalBlocks > 0 ? Math.round((embeddedBlocks / totalBlocks) * 100) : 0;
-    const vaultText = `Vault: ${embeddedBlocks.toLocaleString()}/${totalBlocks.toLocaleString()} (${vaultPercent}%)`;
-
-    if (!this.progressEl) {
-      this.progressEl = createDiv({ cls: 'osc-embed-progress' });
-      this.progressEl.createSpan({ cls: 'osc-embed-progress-text' });
-      this.progressEl.createSpan({ cls: 'osc-embed-progress-vault' });
-      this.progressEl.createDiv({ cls: 'osc-embed-progress-bar' })
-        .createDiv({ cls: 'osc-embed-progress-fill' });
-      // Insert at top of container, before header
-      this.container.prepend(this.progressEl);
+    if (!this.embedProgress) {
+      this.embedProgress = renderEmbedProgress(this.container, this.plugin, { prepend: true });
+    } else {
+      this.embedProgress.update();
     }
-
-    const textEl = this.progressEl.querySelector('.osc-embed-progress-text') as HTMLElement;
-    if (textEl) textEl.setText(runText);
-
-    const vaultEl = this.progressEl.querySelector('.osc-embed-progress-vault') as HTMLElement;
-    if (vaultEl) vaultEl.setText(vaultText);
-
-    const fillEl = this.progressEl.querySelector('.osc-embed-progress-fill') as HTMLElement;
-    if (fillEl) fillEl.style.width = `${runPercent}%`;
   }
 
   renderResults(targetPath: string, results: ConnectionResult[]): void {
@@ -358,8 +359,8 @@ export class ConnectionsView extends ItemView {
     }
     this._lastResultKeys = newKeys;
 
+    this.clearEmbedProgress();
     this.container.empty();
-    this.progressEl = null; // reset reference since container was emptied
     const fileName = targetPath.split('/').pop()?.replace(/\.md$/, '') || 'Unknown';
 
     const header = this.container.createDiv({ cls: 'osc-header' });
@@ -589,6 +590,7 @@ export class ConnectionsView extends ItemView {
 
   showLoading(message = 'Loading...'): void {
     this._lastResultKeys = [];
+    this.clearEmbedProgress();
     this.container.empty();
 
     const wrapper = this.container.createDiv({ cls: 'osc-state' });
@@ -607,8 +609,11 @@ export class ConnectionsView extends ItemView {
   }
 
   showEmpty(message = 'No similar notes found', clear = true): void {
-    if (clear) this._lastResultKeys = [];
-    if (clear) this.container.empty();
+    if (clear) {
+      this._lastResultKeys = [];
+      this.clearEmbedProgress();
+      this.container.empty();
+    }
 
     const wrapper = this.container.createDiv({ cls: 'osc-state' });
     const iconEl = wrapper.createDiv({ cls: 'osc-state-icon' });
@@ -632,6 +637,7 @@ export class ConnectionsView extends ItemView {
 
   showError(message = 'An error occurred'): void {
     this._lastResultKeys = [];
+    this.clearEmbedProgress();
     this.container.empty();
 
     const wrapper = this.container.createDiv({ cls: 'osc-state osc-state--error' });

--- a/src/ui/collection-loader.ts
+++ b/src/ui/collection-loader.ts
@@ -69,6 +69,14 @@ export async function loadCollections(plugin: SmartConnectionsPlugin): Promise<v
     plugin.block_collection.loaded = true;
 
     plugin.source_collection._initializing = false;
+
+    const mk = plugin.source_collection.embed_model_key;
+    const sc = plugin.source_collection.all;
+    const bc = plugin.block_collection.all;
+    console.log(
+      `[SC][Init]   [collections] Loaded: ${sc.length} sources (${sc.filter(e => e.data.embedding_meta?.[mk]).length} with meta, ${sc.filter(e => e.is_unembedded).length} unembedded), ` +
+      `${bc.length} blocks (${bc.filter(e => e.data.embedding_meta?.[mk]).length} with meta, ${bc.filter(e => e.is_unembedded).length} unembedded) [model_key=${mk}]`,
+    );
   } catch (error) {
     console.error('[SC][Init]   [collections] Failed to load collections:', error);
     plugin.notices.show('failed_load_collection_data');
@@ -154,16 +162,28 @@ export function queueUnembeddedEntities(plugin: SmartConnectionsPlugin): number 
 }
 
 export function syncCollectionEmbeddingContext(plugin: SmartConnectionsPlugin): void {
-  const modelKey = plugin.embed_adapter?.model_key;
+  const newModelKey = plugin.embed_adapter?.model_key;
   const modelDims = plugin.embed_adapter?.dims;
 
   if (plugin.source_collection) {
-    if (modelKey) plugin.source_collection.embed_model_key = modelKey;
+    if (newModelKey) {
+      const oldKey = plugin.source_collection.embed_model_key;
+      if (oldKey && oldKey !== 'None' && oldKey !== newModelKey) {
+        console.warn(`[SC][Init] [collections] WARNING: source model_key changed ${oldKey} → ${newModelKey}`);
+      }
+      plugin.source_collection.embed_model_key = newModelKey;
+    }
     plugin.source_collection.embed_model_dims = modelDims;
   }
 
   if (plugin.block_collection) {
-    if (modelKey) plugin.block_collection.embed_model_key = modelKey;
+    if (newModelKey) {
+      const oldKey = plugin.block_collection.embed_model_key;
+      if (oldKey && oldKey !== 'None' && oldKey !== newModelKey) {
+        console.warn(`[SC][Init] [collections] WARNING: block model_key changed ${oldKey} → ${newModelKey}`);
+      }
+      plugin.block_collection.embed_model_key = newModelKey;
+    }
     plugin.block_collection.embed_model_dims = modelDims;
   }
 }

--- a/src/ui/embed-adapters/api-base.ts
+++ b/src/ui/embed-adapters/api-base.ts
@@ -106,38 +106,41 @@ export class EmbedModelApiAdapter {
   async embed_batch(inputs: (EmbedInput | { _embed_input: string })[]): Promise<EmbedResult[]> {
     if (!this.api_key) throw new Error('API key not set');
 
-    // Normalize inputs
-    const normalized_inputs = inputs
-      .map((item) => {
-        const embed_input = 'embed_input' in item ? item.embed_input : item._embed_input;
-        return { ...item, embed_input } as EmbedInput;
-      })
-      .filter((item) => (item.embed_input?.length ?? 0) > 0);
-
-    if (normalized_inputs.length === 0) {
-      console.log('Empty batch (or all items have empty embed_input)');
-      return [];
+    // Normalize ALL inputs — preserve 1:1 mapping with input array.
+    // Items that fail preparation get { vec: [], tokens: 0 } instead of being dropped,
+    // which prevents BatchIntegrityError in the pipeline.
+    const normalized: { item: EmbedInput; originalIndex: number }[] = [];
+    for (let i = 0; i < inputs.length; i++) {
+      const raw = inputs[i];
+      const embed_input = 'embed_input' in raw ? raw.embed_input : raw._embed_input;
+      normalized.push({ item: { ...raw, embed_input } as EmbedInput, originalIndex: i });
     }
 
-    // Prepare inputs while preserving source item mapping
-    const prepared_items = await Promise.all(
-      normalized_inputs.map(async (item) => ({
-        item,
-        prepared: await this.prepare_embed_input(item.embed_input!),
-      })),
+    // Prepare inputs — track which succeeded
+    const prepared = await Promise.all(
+      normalized.map(async (entry) => {
+        if (!entry.item.embed_input || entry.item.embed_input.length === 0) return { ...entry, prepared: null };
+        const prepared = await this.prepare_embed_input(entry.item.embed_input);
+        return { ...entry, prepared: (typeof prepared === 'string' && prepared.length > 0) ? prepared : null };
+      }),
     );
 
-    const valid_items = prepared_items.filter(
-      (entry) => typeof entry.prepared === 'string' && entry.prepared.length > 0,
-    );
+    const valid = prepared.filter((e) => e.prepared !== null);
 
-    if (valid_items.length === 0) {
-      console.log('All embed inputs were trimmed to empty values');
-      return [];
+    // Build result array preserving original positions
+    const results: EmbedResult[] = normalized.map((entry) => ({
+      ...entry.item,
+      vec: [],
+      tokens: 0,
+    } as EmbedResult));
+
+    if (valid.length === 0) {
+      console.log('Empty batch (or all items have empty embed_input)');
+      return results;
     }
 
     // Create request and response adapters
-    const _req = new this.req_adapter(this, valid_items.map((entry) => entry.prepared as string));
+    const _req = new this.req_adapter(this, valid.map((entry) => entry.prepared as string));
     const request_params = _req.to_platform();
 
     const resp = await this.request(request_params);
@@ -146,17 +149,17 @@ export class EmbedModelApiAdapter {
     const embeddings = _res.to_openai();
     if (!embeddings) {
       console.error('Failed to parse embeddings.');
-      return [];
+      return results;
     }
 
-    return valid_items.map((entry, i) => {
-      const item = entry.item;
-      return {
-        ...item,
-        vec: embeddings[i].vec,
-        tokens: embeddings[i].tokens,
-      } as EmbedResult;
-    });
+    // Map API results back to original positions
+    for (let i = 0; i < valid.length && i < embeddings.length; i++) {
+      const idx = valid[i].originalIndex;
+      results[idx].vec = embeddings[i].vec;
+      results[idx].tokens = embeddings[i].tokens;
+    }
+
+    return results;
   }
 
   /**

--- a/src/ui/embed-orchestrator.ts
+++ b/src/ui/embed-orchestrator.ts
@@ -25,7 +25,6 @@ import {
 import { buildKernelModel } from '../domain/embedding/kernel';
 import { errorMessage } from '../utils';
 
-
 // ── Model info helpers ──────────────────────────────────────────────
 
 export function getCurrentModelInfo(plugin: SmartConnectionsPlugin): { adapter: string; modelKey: string; dims: number | null } {
@@ -278,7 +277,10 @@ export async function reembedStaleEntities(plugin: SmartConnectionsPlugin, reaso
     key: 'REFRESH_REQUEST',
     priority: 20,
     run: async () => {
+      // Reset both error message AND phase — without phase reset, runEmbeddingJobNow
+      // returns null when status_state === 'error', silently discarding the re-embed.
       plugin.resetError();
+      plugin.setEmbedPhase('idle');
       const queued = plugin.queueUnembeddedEntities();
       if (queued === 0) {
         plugin.logEmbed('reembed-skip-empty', { reason });
@@ -392,6 +394,26 @@ async function switchEmbeddingModelNow(plugin: SmartConnectionsPlugin, reason: s
     }
 
     const queuedAfterSync = plugin.queueUnembeddedEntities();
+
+    if (queuedAfterSync > 0) {
+      const mk = plugin.block_collection?.embed_model_key ?? '';
+      const expectedDims = plugin.embed_adapter?.dims;
+      let missingMeta = 0, hashMismatch = 0, dimsMismatch = 0;
+      for (const entity of (plugin.block_collection?.all ?? [])) {
+        if (!entity.is_unembedded) continue;
+        const meta = entity.data.embedding_meta?.[mk];
+        if (!meta) { missingMeta++; continue; }
+        const readHash = entity.data.last_read?.hash;
+        if (!readHash || meta.hash !== readHash) { hashMismatch++; continue; }
+        if (typeof expectedDims === 'number' && expectedDims > 0 && typeof meta.dims === 'number' && meta.dims > 0 && meta.dims !== expectedDims) {
+          dimsMismatch++;
+        }
+      }
+      plugin.logEmbed('switch-queued', { adapter: targetAdapter, modelKey: targetModelKey, current: queuedAfterSync, total: queuedAfterSync });
+      console.log(`[SC][Embed] switch-queued breakdown: missingMeta=${missingMeta} hashMismatch=${hashMismatch} dimsMismatch=${dimsMismatch}`);
+    }
+
+    await saveCollections(plugin);
     await plugin.initPipeline();
 
     // Notify success

--- a/src/ui/embed-progress.ts
+++ b/src/ui/embed-progress.ts
@@ -1,0 +1,58 @@
+/**
+ * @file embed-progress.ts
+ * @description Shared dual progress bar component (Notes + Blocks) for ConnectionsView and Settings.
+ * Uses Obsidian's native ProgressBarComponent. No ETA.
+ */
+
+import { ProgressBarComponent } from 'obsidian';
+
+/**
+ * Renders a dual progress bar (Notes + Blocks) into the given container element.
+ * Returns handles to update values and destroy the DOM.
+ *
+ * @param prepend - When true, inserts the wrapper at the top of container (default: appended)
+ */
+export function renderEmbedProgress(
+  container: HTMLElement,
+  plugin: any,
+  { prepend = false }: { prepend?: boolean } = {},
+): { update(): void; destroy(): void } {
+  const wrapper = container.createDiv({ cls: 'osc-embed-dual-progress' });
+  if (prepend) {
+    container.prepend(wrapper); // moves from last to first position
+  }
+
+  // Notes row
+  const notesRow = wrapper.createDiv({ cls: 'osc-embed-dual-progress-row' });
+  notesRow.createSpan({ cls: 'osc-embed-dual-progress-label', text: 'Notes' });
+  const notesBar = new ProgressBarComponent(notesRow);
+  const notesCount = notesRow.createSpan({ cls: 'osc-embed-dual-progress-count' });
+
+  // Blocks row
+  const blocksRow = wrapper.createDiv({ cls: 'osc-embed-dual-progress-row' });
+  blocksRow.createSpan({ cls: 'osc-embed-dual-progress-label', text: 'Blocks' });
+  const blocksBar = new ProgressBarComponent(blocksRow);
+  const blocksCount = blocksRow.createSpan({ cls: 'osc-embed-dual-progress-count' });
+
+  function update(): void {
+    const notesTotal = plugin.app?.vault?.getMarkdownFiles()?.length ?? 0;
+    const notesEmbedded = plugin.source_collection?.all?.filter((s: any) => s.vec)?.length ?? 0;
+    const notesPct = notesTotal > 0 ? Math.round((notesEmbedded / notesTotal) * 100) : 0;
+    notesBar.setValue(notesPct);
+    notesCount.setText(`${notesEmbedded.toLocaleString()}/${notesTotal.toLocaleString()}`);
+
+    const blocksAll = plugin.block_collection?.all ?? [];
+    const blocksTotal = blocksAll.length;
+    const blocksEmbedded = blocksAll.filter((b: any) => b.vec).length;
+    const blocksPct = blocksTotal > 0 ? Math.round((blocksEmbedded / blocksTotal) * 100) : 0;
+    blocksBar.setValue(blocksPct);
+    blocksCount.setText(`${blocksEmbedded.toLocaleString()}/${blocksTotal.toLocaleString()}`);
+  }
+
+  update();
+
+  return {
+    update,
+    destroy: () => wrapper.remove(),
+  };
+}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -10,7 +10,6 @@ import {
   Plugin,
   Modal,
   ButtonComponent,
-  ProgressBarComponent,
   EventRef,
 } from 'obsidian';
 import type { PluginSettings } from '../types/settings';
@@ -20,7 +19,7 @@ import {
   renderHostField as renderHostFieldExternal,
   renderSearchModelPicker,
 } from './settings-model-picker';
-import { formatEta } from '../utils';
+import { renderEmbedProgress } from './embed-progress';
 
 interface SmartConnectionsPlugin extends Plugin {
   settings?: PluginSettings;
@@ -96,7 +95,7 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
   private statsGridEl: HTMLElement | null = null;
   private currentRunEl: HTMLElement | null = null;
   private currentRunSettingEl: HTMLElement | null = null;
-  private progressBarEl: HTMLElement | null = null;
+  private embedProgress: ReturnType<typeof renderEmbedProgress> | null = null;
 
   constructor(app: App, plugin: SmartConnectionsPlugin) {
     super(app, plugin);
@@ -112,7 +111,7 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
     this.statsGridEl = null;
     this.currentRunEl = null;
     this.currentRunSettingEl = null;
-    this.progressBarEl = null;
+    this.embedProgress = null;
   }
 
   hide(): void {
@@ -516,25 +515,16 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
     this.renderStatCard(statsGrid, 'Pending', pending.toLocaleString(), pending > 0 ? 'amber' : undefined);
     this.renderStatCard(statsGrid, 'Progress', `${pct}%`, pct >= 100 ? 'green' : undefined);
 
-    const progressWrap = containerEl.createDiv({ cls: 'osc-settings-embed-progress' });
-    const progressBar = new ProgressBarComponent(progressWrap).setValue(pct);
-    this.progressBarEl = (progressBar as any).progressBar ?? progressWrap.querySelector('progress') as HTMLElement | null;
-
-    const runCurrent = activeCtx?.current ?? embedded;
-    const runTotal = activeCtx?.total ?? total;
-    const runPercent = runTotal > 0 ? Math.round((runCurrent / runTotal) * 100) : 0;
-    const currentItem = activeCtx?.currentSourcePath ?? activeCtx?.currentEntityKey ?? '-';
+    this.embedProgress = renderEmbedProgress(containerEl, this.plugin);
 
     {
+      const runCurrent = activeCtx?.current ?? embedded;
+      const runTotal = activeCtx?.total ?? total;
+      const runPercent = runTotal > 0 ? Math.round((runCurrent / runTotal) * 100) : 0;
+      const currentItem = activeCtx?.currentSourcePath ?? activeCtx?.currentEntityKey ?? '-';
       let runDesc = '-';
       if (status === 'embedding') {
-        const elapsedMs = activeCtx?.startedAt ? Date.now() - activeCtx.startedAt : 0;
-        const etaMs = activeCtx && activeCtx.current > 0 && activeCtx.total > activeCtx.current
-          ? Math.round((elapsedMs / activeCtx.current) * (activeCtx.total - activeCtx.current))
-          : null;
-        const etaStr = formatEta(etaMs);
-        const etaPart = etaStr ? ` • ETA: ${etaStr}` : '';
-        runDesc = `Run #${activeCtx?.runId ?? '-'} • ${runCurrent.toLocaleString()}/${runTotal.toLocaleString()} (${runPercent}%)${etaPart} • ${currentItem}`;
+        runDesc = `Run #${activeCtx?.runId ?? '-'} • ${runCurrent.toLocaleString()}/${runTotal.toLocaleString()} (${runPercent}%) • ${currentItem}`;
       } else if (status === 'error') {
         runDesc = 'Embedding run encountered an error. Check notices for details.';
       }
@@ -580,7 +570,8 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
       this.renderStatCard(this.statsGridEl, 'Progress', `${pct}%`, pct >= 100 ? 'green' : undefined);
     }
 
-    // Live-update current run section
+    // Live-update progress bars and current run section
+    this.embedProgress?.update();
     const ctx = (this.plugin as any).current_embed_context;
     const status = this.plugin.status_state ?? 'idle';
     if (this.currentRunEl) {
@@ -589,19 +580,10 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
         const runCurrent: number = ctx.current ?? 0;
         const runTotal: number = ctx.total ?? 0;
         const runPercent = runTotal > 0 ? Math.round((runCurrent / runTotal) * 100) : 0;
-        const elapsedMs = ctx.startedAt ? Date.now() - ctx.startedAt : 0;
-        const etaMs = runCurrent > 0 && runTotal > runCurrent
-          ? Math.round((elapsedMs / runCurrent) * (runTotal - runCurrent))
-          : null;
-        const etaStr = formatEta(etaMs);
-        const etaPart = etaStr ? ` • ETA: ${etaStr}` : '';
         const currentItem: string = ctx.currentSourcePath ?? ctx.currentEntityKey ?? '-';
         this.currentRunEl.setText(
-          `Run #${ctx.runId ?? '-'} • ${runCurrent.toLocaleString()}/${runTotal.toLocaleString()} (${runPercent}%)${etaPart} • ${currentItem}`,
+          `Run #${ctx.runId ?? '-'} • ${runCurrent.toLocaleString()}/${runTotal.toLocaleString()} (${runPercent}%) • ${currentItem}`,
         );
-        if (this.progressBarEl) {
-          (this.progressBarEl as any).value = runPercent;
-        }
       } else {
         if (this.currentRunSettingEl) this.currentRunSettingEl.style.display = 'none';
       }
@@ -683,7 +665,7 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
   ): void {
     const card = containerEl.createDiv({ cls: 'osc-stat-card' });
     if (tone === 'green') card.addClass('osc-stat--green');
-    if (tone === 'amber') card.addClass('osc-stat--amber');
+    else if (tone === 'amber') card.addClass('osc-stat--amber');
     card.createDiv({ cls: 'osc-stat-value', text: value });
     card.createDiv({ cls: 'osc-stat-label', text: label });
   }

--- a/src/ui/status-bar.ts
+++ b/src/ui/status-bar.ts
@@ -6,7 +6,6 @@
 import { setIcon } from 'obsidian';
 import type SmartConnectionsPlugin from '../main';
 import { ConnectionsView } from './ConnectionsView';
-import { formatEta } from '../utils';
 
 let cachedVaultTag = '';
 let cachedIcon = '';
@@ -92,16 +91,10 @@ export function refreshStatus(plugin: SmartConnectionsPlugin): void {
       const runTotal = ctx?.total ?? 0;
       const runPercent = runTotal > 0 ? Math.round((runCurrent / runTotal) * 100) : 0;
       plugin.status_msg.setText(`OC: ${runCurrent}/${runTotal} (${runPercent}%)`);
-      const elapsedMs = ctx?.startedAt ? Date.now() - ctx.startedAt : 0;
-      const etaMs = ctx && ctx.current > 0 && ctx.total > ctx.current
-        ? Math.round((elapsedMs / ctx.current) * (ctx.total - ctx.current))
-        : null;
-      const etaStr = formatEta(etaMs);
-      const etaPart = etaStr ? `\nETA: ${etaStr}` : '';
       const currentNote = ctx?.currentSourcePath ?? '-';
       plugin.status_container.setAttribute(
         'title',
-        `Embedding in progress\nRun: #${ctx?.runId ?? '-'}${etaPart}\nRun: ${runCurrent}/${runTotal} (${runPercent}%)\nVault: ${vaultTag}\nModel: ${modelTag}${model.dims ? ` (${model.dims}d)` : ''}\nCurrent: ${currentNote}`,
+        `Embedding in progress\nRun: #${ctx?.runId ?? '-'}\nRun: ${runCurrent}/${runTotal} (${runPercent}%)\nVault: ${vaultTag}\nModel: ${modelTag}${model.dims ? ` (${model.dims}d)` : ''}\nCurrent: ${currentNote}`,
       );
       break;
     }

--- a/test/mocks/obsidian.ts
+++ b/test/mocks/obsidian.ts
@@ -184,6 +184,7 @@ function patchObsidianEl(el: HTMLElement): HTMLElement {
     this.appendChild(child);
     return child;
   };
+  (el as any).setText = function(text: string): void { this.textContent = text; };
   return el;
 }
 

--- a/test/model-key-remap.test.ts
+++ b/test/model-key-remap.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @file model-key-remap.test.ts
+ * @description Integration test for upsertEmbedding write-asymmetry fix.
+ *
+ * Root cause: upsertEmbedding previously returned early when vec=[] (lazy-loaded),
+ * which meant embed_hash in entity_embeddings never got synced after a save.
+ * This test verifies that is_unembedded stays false after a save-while-lazy cycle.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'module';
+import { readFileSync } from 'fs';
+import type { EntityData } from '../src/types/entities';
+import { EmbeddingEntity } from '../src/domain/entities/EmbeddingEntity';
+
+const require = createRequire(import.meta.url);
+const wasmBinary = new Uint8Array(readFileSync(require.resolve('sql.js/dist/sql-wasm.wasm')));
+
+function createVaultAdapter() {
+  const files = new Map<string, Uint8Array>();
+  return {
+    files,
+    readBinary: vi.fn(async (path: string) => {
+      if (path.endsWith('sql-wasm.wasm')) return wasmBinary;
+      const file = files.get(path);
+      if (!file) throw new Error(`missing ${path}`);
+      return file;
+    }),
+    exists: vi.fn(async (path: string) => {
+      if (path.endsWith('sql-wasm.wasm')) return true;
+      return files.has(path);
+    }),
+    writeBinary: vi.fn(async (path: string, data: Uint8Array | Buffer) => {
+      files.set(path, data instanceof Uint8Array ? data : new Uint8Array(data));
+    }),
+  };
+}
+
+function makeFullEntity(path: string, vec: number[]) {
+  return {
+    key: path,
+    data: {
+      path,
+      embeddings: { 'test-model': { vec, tokens: vec.length } },
+      last_read: { hash: `hash:${path}`, size: vec.length * 4, mtime: 123 },
+      embedding_meta: {
+        'test-model': { hash: `hash:${path}`, dims: vec.length, updated_at: 456 },
+      },
+    } as EntityData,
+    _queue_save: true,
+    _queue_embed: false,
+    _remove_all_embeddings: false,
+    embed_model_key: 'test-model',
+    is_unembedded: false,
+    validate_save: () => true,
+  };
+}
+
+function createSavingCollection(entities: any[]) {
+  const deleted = new Set<string>();
+  return {
+    embed_model_key: 'test-model',
+    embed_model_dims: 2,
+    all: entities,
+    get save_queue() { return entities.filter(e => e._queue_save); },
+    consume_deleted_keys(): string[] {
+      const keys = Array.from(deleted);
+      deleted.clear();
+      return keys;
+    },
+    restore_deleted_keys(keys: string[]) { keys.forEach(k => deleted.add(k)); },
+    create_or_update: vi.fn(),
+  } as any;
+}
+
+/** Loading collection that creates real EmbeddingEntity instances so is_unembedded is computed correctly. */
+function createRealEntityCollection(modelKey: string) {
+  const all: EmbeddingEntity<any>[] = [];
+  const byKey = new Map<string, EmbeddingEntity<any>>();
+
+  const coll: any = {
+    embed_model_key: modelKey,
+    embed_model_dims: undefined as number | undefined,
+    all,
+    settings: { min_chars: 0 },
+    get save_queue() { return all.filter(e => (e as any)._queue_save); },
+    consume_deleted_keys(): string[] { return []; },
+    restore_deleted_keys(): void {},
+    delete: () => {},
+    create_or_update(data: Partial<EntityData>) {
+      const key = String(data.path ?? '');
+      const existing = byKey.get(key);
+      if (existing) {
+        Object.assign(existing.data, data);
+        return existing;
+      }
+      const entity = new EmbeddingEntity(coll, data);
+      all.push(entity);
+      byKey.set(key, entity);
+      return entity;
+    },
+  };
+  return coll;
+}
+
+afterEach(async () => {
+  const { closeSqliteDatabases } = await import('../src/domain/entities/sqlite-data-adapter');
+  await closeSqliteDatabases();
+});
+
+describe('upsertEmbedding write-asymmetry fix', () => {
+  it('is_unembedded stays false after save-with-lazy-vec cycle', async () => {
+    const { SqliteDataAdapter, closeSqliteDatabases } = await import('../src/domain/entities/sqlite-data-adapter');
+    const vaultAdapter = createVaultAdapter();
+    const ns = 'open-connections:/tmp/test-lazy-vec:.obsidian/plugins/open-connections/.smart-env';
+
+    // ── Step 1: Save entity with full embedding ──────────────────────────
+    const firstColl = createSavingCollection([makeFullEntity('note-a.md#h1', [1, 0])]);
+    const firstAdapter = new SqliteDataAdapter(firstColl, 'smart_blocks', ns);
+    firstAdapter.initVaultContext(vaultAdapter, '.obsidian', 'open-connections');
+    await firstAdapter.save();
+    await closeSqliteDatabases();
+
+    // ── Step 2: Reload (vec becomes [] — lazy-loaded) ────────────────────
+    const secondColl = createRealEntityCollection('test-model');
+    const secondAdapter = new SqliteDataAdapter(secondColl, 'smart_blocks', ns);
+    secondAdapter.initVaultContext(vaultAdapter, '.obsidian', 'open-connections');
+    await secondAdapter.load();
+
+    expect(secondColl.all).toHaveLength(1);
+    const lazyEntity = secondColl.all[0];
+    expect(lazyEntity.vec).toBeNull(); // vec is lazy (not loaded into memory)
+    expect(lazyEntity.is_unembedded).toBe(false); // sanity: should already be embedded
+
+    // ── Step 3: Save while vec is lazy (simulates autosave / file-watcher) ──
+    (lazyEntity as any)._queue_save = true;
+    await secondAdapter.save();
+    await closeSqliteDatabases();
+
+    // ── Step 4: Reload and verify is_unembedded is still false ───────────
+    const thirdColl = createRealEntityCollection('test-model');
+    const thirdAdapter = new SqliteDataAdapter(thirdColl, 'smart_blocks', ns);
+    thirdAdapter.initVaultContext(vaultAdapter, '.obsidian', 'open-connections');
+    await thirdAdapter.load();
+
+    expect(thirdColl.all).toHaveLength(1);
+    expect(thirdColl.all[0].is_unembedded).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **Re-embedding bug fix**: `upsertEmbedding` now maintains hash coupling even when vec is lazy-loaded — prevents false re-embedding on every reload
- **6 HIGH structural audit fixes**: CASCADE removal, save flush on unload, API adapter 1:1 batch mapping, error phase recovery, waitForSync timeout, DOM cleanup
- **Progress UI redesign**: Dual progress bars (Notes + Blocks) using Obsidian ProgressBarComponent, ETA removed, always visible when incomplete
- **ConnectionsView model-switch reset**: Clears stale results when embedding model changes

## Test plan

- [x] `pnpm run ci` passes (24 files, 208 tests)
- [x] Runtime QA on local Ataraxia: delete DB → embed → reload → `hashMismatch=0`
- [x] Dual progress bars verified in ConnectionsView and Settings
- [x] No ETA text in UI (DOM searched)
- [x] Code reviewed by Opus agents (0 CRITICAL, 0 HIGH after fixes)
- [x] 5-agent structural audit: SQLite persistence, pipeline state, init lifecycle, event system, observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)