### PR TITLE
fix(memory): eliminate OOM on large vaults via 3-phase memory architecture

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-	"id": "open-connections",
-	"name": "Open Connections",
-	"author": "beomsu koh",
-	"description": "Chat with your notes & see links to related content with Local or Remote models.",
-	"minAppVersion": "1.1.0",
-	"authorUrl": "https://github.com/beomsuKoh/obsidian-smart-connections",
-	"isDesktopOnly": true,
-	"version": "3.9.4"
+  "id": "open-connections",
+  "name": "Open Connections",
+  "author": "beomsu koh",
+  "description": "Chat with your notes & see links to related content with Local or Remote models.",
+  "minAppVersion": "1.1.0",
+  "authorUrl": "https://github.com/beomsuKoh/obsidian-smart-connections",
+  "isDesktopOnly": true,
+  "version": "3.9.4"
 }

--- a/src/domain/embedding-pipeline.ts
+++ b/src/domain/embedding-pipeline.ts
@@ -147,11 +147,18 @@ export class EmbeddingPipeline {
         this.should_halt = true;
       };
 
+      const pendingEviction: EmbeddingEntity[] = [];
+
       const flush_save = async (): Promise<void> => {
         if (!on_save) return;
         const run = save_chain.then(() => on_save());
         save_chain = run.catch(() => undefined);
         await run;
+        // Evict vectors for entities persisted in this save
+        const toEvict = pendingEviction.splice(0);
+        for (const entity of toEvict) {
+          entity.evictVec?.();
+        }
       };
 
       // Concurrent batch dispatcher
@@ -213,7 +220,7 @@ export class EmbeddingPipeline {
           }
 
           try {
-            const { succeeded, failed_count } = await this.process_batch(ready, max_retries);
+            const { succeeded, failed_count } = await this.process_batch(ready, max_retries, pendingEviction);
             local.success += succeeded;
             local.failed += failed_count;
             local.skipped += skipped_in_batch.length;
@@ -332,6 +339,7 @@ export class EmbeddingPipeline {
   private async process_batch(
     batch: EmbeddingEntity[],
     max_retries: number,
+    pendingEviction?: EmbeddingEntity[],
   ): Promise<{ succeeded: number; failed_count: number }> {
     let retries = 0;
     let last_error: Error | null = null;
@@ -366,6 +374,7 @@ export class EmbeddingPipeline {
 
           entity.vec = emb.vec;
           entity.tokens = emb.tokens;
+          pendingEviction?.push(entity);
 
           if (entity.data.last_read) {
             entity.data.last_embed = { ...entity.data.last_read };

--- a/src/domain/entities/BlockCollection.ts
+++ b/src/domain/entities/BlockCollection.ts
@@ -18,6 +18,7 @@ export class BlockCollection extends EntityCollection<EmbeddingBlock> {
   source_collection?: SourceCollection;
 
   private _sourceIndex: Map<string, Set<string>> = new Map();
+  private _cachedEmbeddedSourceCount = 0;
 
   constructor(
     data_dir: string,
@@ -47,6 +48,23 @@ export class BlockCollection extends EntityCollection<EmbeddingBlock> {
       set.delete(key);
       if (set.size === 0) this._sourceIndex.delete(sourceKey);
     }
+  }
+
+  /** Count of distinct source files with at least one embedded block */
+  get embeddedSourceCount(): number {
+    return this._cachedEmbeddedSourceCount;
+  }
+
+  override recomputeEmbeddedCount(): void {
+    super.recomputeEmbeddedCount();
+    let count = 0;
+    for (const [, blockKeys] of this._sourceIndex) {
+      for (const key of blockKeys) {
+        const block = this.items[key];
+        if (block?.has_embed()) { count++; break; }
+      }
+    }
+    this._cachedEmbeddedSourceCount = count;
   }
 
   /**

--- a/src/domain/entities/EmbeddingEntity.ts
+++ b/src/domain/entities/EmbeddingEntity.ts
@@ -78,7 +78,7 @@ export class EmbeddingEntity {
     }
   }
 
-  private has_dim_mismatch(vec: number[] | null): boolean {
+  private has_dim_mismatch(vec: number[] | Float32Array | null): boolean {
     const expected_dims = (this.collection as any).embed_model_dims;
     return (
       typeof expected_dims === 'number' &&
@@ -165,7 +165,7 @@ export class EmbeddingEntity {
    * Get current embedding vector
    * CRITICAL: Format is data.embeddings[model_key].vec
    */
-  get vec(): number[] | null {
+  get vec(): number[] | Float32Array | null {
     const vec = this.embedding_data.vec;
     return (vec && vec.length > 0) ? vec : null;
   }
@@ -174,7 +174,7 @@ export class EmbeddingEntity {
    * Set embedding vector
    * CRITICAL: Must maintain data.embeddings[model_key] = { vec, tokens } format
    */
-  set vec(vec: number[] | null) {
+  set vec(vec: number[] | Float32Array | null) {
     if (vec === null) {
       if (this.data.embeddings[this.embed_model_key]) {
         this.data.embeddings[this.embed_model_key].vec = [];
@@ -313,6 +313,18 @@ export class EmbeddingEntity {
     const read_hash = this.read_hash;
     const active_hash = this.active_embedding_meta?.hash;
     return !!read_hash && !!active_hash && read_hash === active_hash;
+  }
+
+  /**
+   * Evict the in-memory vector after it has been persisted to SQLite.
+   * Sets vec to [] without triggering queue_save or clearing metadata.
+   * After eviction, has_embed() still returns true via hash comparison.
+   */
+  evictVec(): void {
+    const model_key = this.embed_model_key;
+    if (this.data.embeddings[model_key]) {
+      this.data.embeddings[model_key].vec = [];
+    }
   }
 
   /**

--- a/src/domain/entities/EntityCollection.ts
+++ b/src/domain/entities/EntityCollection.ts
@@ -14,6 +14,9 @@ export abstract class EntityCollection<T extends EmbeddingEntity> {
   embed_model_key: string = 'None';
   embed_model_dims?: number;
 
+  /** Cached embedded count — recomputed at event boundaries (load, save, clear) */
+  private _cachedEmbeddedCount = 0;
+
   constructor(
     data_dir: string,
     settings: any = {},
@@ -62,7 +65,6 @@ export abstract class EntityCollection<T extends EmbeddingEntity> {
     }
 
     item.init();
-
     return item;
   }
 
@@ -116,7 +118,7 @@ export abstract class EntityCollection<T extends EmbeddingEntity> {
     await this.data_adapter.save_batch(queue);
   }
 
-  async nearest(vec: number[], filter: SearchFilter = {}): Promise<ConnectionResult[]> {
+  async nearest(vec: number[] | Float32Array, filter: SearchFilter = {}): Promise<ConnectionResult[]> {
     const limit = filter.limit ?? 50;
     const fetch_multiplier = filter.filter_fn ? 6 : 3;
     const matches = await this.data_adapter.query_nearest(vec, filter, fetch_multiplier);
@@ -149,11 +151,27 @@ export abstract class EntityCollection<T extends EmbeddingEntity> {
     return Object.keys(this.items).length;
   }
 
-  clear(): void {
-    this.items = {};
+  /** Delegates to .size for callers that use totalCount */
+  get totalCount(): number {
+    return this.size;
   }
 
-  private async ensure_entity_vector(entity: T): Promise<void> {
+  /** Recompute the embedded count from source of truth. Call after load, save, or clear. */
+  recomputeEmbeddedCount(): void {
+    this._cachedEmbeddedCount = this.all.filter(item => item.has_embed()).length;
+  }
+
+  /** O(1) count of entities with valid embeddings */
+  get embeddedCount(): number {
+    return this._cachedEmbeddedCount;
+  }
+
+  clear(): void {
+    this.items = {};
+    this._cachedEmbeddedCount = 0;
+  }
+
+  async ensure_entity_vector(entity: T): Promise<void> {
     if (entity.vec && entity.vec.length > 0) return;
     const model_key = this.embed_model_key;
     if (!model_key || model_key === 'None') return;

--- a/src/domain/entities/sqlite-data-adapter.ts
+++ b/src/domain/entities/sqlite-data-adapter.ts
@@ -41,16 +41,9 @@ function toDbKey(storageNamespace: string): string {
     .slice(0, 200) || 'open_connections';
 }
 
-function vecToBlob(vec: number[]): Uint8Array {
-  const f32 = new Float32Array(vec);
+function vecToBlob(vec: number[] | Float32Array): Uint8Array {
+  const f32 = vec instanceof Float32Array ? vec : new Float32Array(vec);
   return new Uint8Array(f32.buffer);
-}
-
-function blobToVec(blob: Uint8Array | ArrayBuffer | null): number[] | null {
-  if (!blob) return null;
-  const buf = blob instanceof Uint8Array ? blob.buffer.slice(blob.byteOffset, blob.byteOffset + blob.byteLength) : blob;
-  if (buf.byteLength === 0 || buf.byteLength % 4 !== 0) return null;
-  return Array.from(new Float32Array(buf));
 }
 
 function blobToF32(blob: Uint8Array | ArrayBuffer | null): Float32Array | null {
@@ -821,7 +814,7 @@ export class SqliteDataAdapter<T extends EmbeddingEntity> {
     entityKey: string,
     modelKey: string,
   ): Promise<{
-    vec: number[] | null;
+    vec: Float32Array | null;
     tokens?: number;
     meta?: EmbeddingModelMeta;
   }> {
@@ -840,7 +833,7 @@ export class SqliteDataAdapter<T extends EmbeddingEntity> {
         }
 
         const row = stmt.getAsObject();
-        const vec = blobToVec(row.vec as Uint8Array | null);
+        const vec = blobToF32(row.vec as Uint8Array | null);
         const meta = row.embed_hash
           ? {
             hash: row.embed_hash as string,
@@ -865,11 +858,11 @@ export class SqliteDataAdapter<T extends EmbeddingEntity> {
   // -----------------------------------------------------------------------
 
   async query_nearest(
-    vec: number[],
+    vec: number[] | Float32Array,
     filter: SearchFilter = {},
     fetchMultiplier: number = 3,
   ): Promise<QueryMatch[]> {
-    if (!vec || !Array.isArray(vec) || vec.length === 0) return [];
+    if (!vec || vec.length === 0) return [];
 
     const modelKey = this.collection.embed_model_key;
     if (!modelKey || modelKey === 'None') return [];
@@ -927,7 +920,7 @@ export class SqliteDataAdapter<T extends EmbeddingEntity> {
 
       try {
         // Compute cosine similarity in JS using Float32Array to skip Array.from() conversion
-        const queryF32 = new Float32Array(vec);
+        const queryF32 = vec instanceof Float32Array ? vec : new Float32Array(vec);
         const scored: QueryMatch[] = [];
         while (stmt.step()) {
           const row = stmt.getAsObject();

--- a/src/main.ts
+++ b/src/main.ts
@@ -294,7 +294,7 @@ export default class SmartConnectionsPlugin extends Plugin {
       const activeFile = this.app.workspace.getActiveFile();
       if (!activeFile) return;
 
-      // Find embedded blocks for this file and average their vectors
+      // Find embedded blocks for this file and load their vectors on demand
       const fileBlocks = this.block_collection.all.filter(
         (b: any) => b.source_key === activeFile.path && b.has_embed(),
       );
@@ -303,10 +303,18 @@ export default class SmartConnectionsPlugin extends Plugin {
         return;
       }
 
-      const avgVec = average_vectors(fileBlocks.map((b: any) => b.vec));
+      await Promise.all(fileBlocks.map((b: any) => this.block_collection.ensure_entity_vector(b)));
+      const loadedBlocks = fileBlocks.filter((b: any) => b.vec && b.vec.length > 0);
+      if (loadedBlocks.length === 0) {
+        el.createEl('p', { text: 'No embedding available for this note.', cls: 'osc-state-text' });
+        return;
+      }
+
+      const avgVec = average_vectors(loadedBlocks.map((b: any) => b.vec));
+      loadedBlocks.forEach((b: any) => (b as any).evictVec?.());
 
       try {
-        const blockKeys = new Set(fileBlocks.map((b: any) => b.key));
+        const blockKeys = fileBlocks.map((b: any) => b.key);
         const results = await this.block_collection.nearest(avgVec, { limit: limit * 3, exclude: blockKeys });
         // Dedupe by source path, keep highest score
         const seen = new Map<string, { score: number; path: string; heading: string }>();

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -31,7 +31,7 @@ export interface LastMetadata {
  */
 export interface EmbeddingData {
   /** The embedding vector */
-  vec: number[];
+  vec: number[] | Float32Array;
   /** Token count (if available) */
   tokens?: number;
 }
@@ -160,7 +160,7 @@ export interface EmbeddingEntity {
   data: EntityData;
 
   /** Current embedding vector (cached from data.embeddings[model_key].vec) */
-  vec: number[] | null;
+  vec: number[] | Float32Array | null;
 
   /** Active-model freshness metadata */
   active_embedding_meta?: EmbeddingModelMeta;
@@ -203,6 +203,12 @@ export interface EmbeddingEntity {
    * Update active-model embedding metadata
    */
   set_active_embedding_meta(meta: EmbeddingModelMeta): void;
+
+  /**
+   * Evict the embedding vector from memory after it has been persisted to SQLite.
+   * Sets vec to [] in data.embeddings[model_key] without triggering queue_save.
+   */
+  evictVec?(): void;
 
   /**
    * Check if entity needs re-embedding

--- a/src/ui/ConnectionsView.ts
+++ b/src/ui/ConnectionsView.ts
@@ -327,9 +327,8 @@ export class ConnectionsView extends ItemView {
   private updateProgressBanner(): void {
     if (!this.container) return;
 
-    const blocksAll = this.plugin.block_collection?.all ?? [];
-    const totalBlocks = blocksAll.length;
-    const embeddedBlocks = totalBlocks > 0 ? blocksAll.filter((b: any) => b.vec).length : 0;
+    const totalBlocks = this.plugin.block_collection?.size ?? 0;
+    const embeddedBlocks = this.plugin.block_collection?.embeddedCount ?? 0;
     const isComplete = totalBlocks > 0 && embeddedBlocks >= totalBlocks;
 
     const modelLoading = !this.plugin.embed_ready && this.plugin.status_state !== 'error';

--- a/src/ui/block-connections.ts
+++ b/src/ui/block-connections.ts
@@ -46,11 +46,16 @@ export async function getBlockConnections(
   }
 
   const fileBlocks = blockCollection.for_source(filePath);
-  const embedded = fileBlocks.filter(b => b.vec);
+  const embedded = fileBlocks.filter(b => b.has_embed());
   if (embedded.length === 0) return [];
 
-  const avgVec = average_vectors(embedded.map(b => b.vec!));
-  const excludeKeys = new Set(fileBlocks.map(b => b.key));
+  await Promise.all(embedded.map(b => blockCollection.ensure_entity_vector(b)));
+  const withVec = embedded.filter(b => b.vec && b.vec.length > 0);
+  if (withVec.length === 0) return [];
+
+  const avgVec = average_vectors(withVec.map(b => b.vec!));
+  withVec.forEach(b => b.evictVec());
+  const excludeKeys = fileBlocks.map(b => b.key);
   const results = await blockCollection.nearest(avgVec, { limit: limit * 3, exclude: excludeKeys });
 
   // Dedupe by source path, keep highest score

--- a/src/ui/collection-loader.ts
+++ b/src/ui/collection-loader.ts
@@ -68,14 +68,15 @@ export async function loadCollections(plugin: SmartConnectionsPlugin): Promise<v
     plugin.source_collection.loaded = true;
     plugin.block_collection.loaded = true;
 
+    plugin.source_collection.recomputeEmbeddedCount();
+    plugin.block_collection.recomputeEmbeddedCount();
+
     plugin.source_collection._initializing = false;
 
     const mk = plugin.source_collection.embed_model_key;
-    const sc = plugin.source_collection.all;
-    const bc = plugin.block_collection.all;
     console.log(
-      `[SC][Init]   [collections] Loaded: ${sc.length} sources (${sc.filter(e => e.data.embedding_meta?.[mk]).length} with meta, ${sc.filter(e => e.is_unembedded).length} unembedded), ` +
-      `${bc.length} blocks (${bc.filter(e => e.data.embedding_meta?.[mk]).length} with meta, ${bc.filter(e => e.is_unembedded).length} unembedded) [model_key=${mk}]`,
+      `[SC][Init]   [collections] Loaded: ${plugin.source_collection.size} sources (${plugin.source_collection.embeddedCount} embedded), ` +
+      `${plugin.block_collection.size} blocks (${plugin.block_collection.embeddedCount} embedded) [model_key=${mk}]`,
     );
   } catch (error) {
     console.error('[SC][Init]   [collections] Failed to load collections:', error);
@@ -115,6 +116,8 @@ export async function processNewSourcesChunked(plugin: SmartConnectionsPlugin): 
 
     await plugin.source_collection.data_adapter.save();
     await plugin.block_collection.data_adapter.save();
+    plugin.source_collection.recomputeEmbeddedCount();
+    plugin.block_collection.recomputeEmbeddedCount();
 
     const chunkQueued = queueUnembeddedEntities(plugin);
     const processed = Math.min(i + chunkSize, total);

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -79,7 +79,7 @@ export function registerCommands(plugin: Plugin): void {
       if (!activeFile || !p.block_collection) return;
 
       const blockCollection = p.block_collection as BlockCollection;
-      const hasEmbedded = blockCollection.for_source(activeFile.path).some((b: EmbeddingBlock) => b.vec);
+      const hasEmbedded = blockCollection.for_source(activeFile.path).some((b: EmbeddingBlock) => b.has_embed());
       if (!hasEmbedded) {
         p.notices?.show('no_embedding_for_context');
         return;
@@ -114,7 +114,7 @@ export function registerCommands(plugin: Plugin): void {
       if (!activeFile || !p.block_collection) return;
 
       const blockCollection = p.block_collection as BlockCollection;
-      if (!blockCollection.for_source(activeFile.path).some((b: EmbeddingBlock) => b.vec)) return;
+      if (!blockCollection.for_source(activeFile.path).some((b: EmbeddingBlock) => b.has_embed())) return;
 
       try {
         const results = await getBlockConnections(blockCollection, activeFile.path, { limit: 20 });

--- a/src/ui/embed-orchestrator.ts
+++ b/src/ui/embed-orchestrator.ts
@@ -580,6 +580,8 @@ export async function runEmbeddingJobNow(plugin: SmartConnectionsPlugin, reason:
       },
       on_save: async () => {
         await saveCollections(plugin);
+        plugin.block_collection?.recomputeEmbeddedCount();
+        plugin.source_collection?.recomputeEmbeddedCount();
         if (plugin.current_embed_context?.runId === runId) {
           ctx.saveCount += 1;
           publishEmbedContext(plugin, ctx);
@@ -619,6 +621,8 @@ export async function runEmbeddingJobNow(plugin: SmartConnectionsPlugin, reason:
 
     if (stats.outcome === 'completed') {
       await saveCollections(plugin);
+      plugin.block_collection?.recomputeEmbeddedCount();
+      plugin.source_collection?.recomputeEmbeddedCount();
       ctx.saveCount += 1;
     }
 

--- a/src/ui/embed-progress.ts
+++ b/src/ui/embed-progress.ts
@@ -50,12 +50,11 @@ export function renderEmbedProgress(
   function update(): void {
     if (destroyed) return;
 
-    const blocksAll = plugin.block_collection?.all ?? [];
-    const totalBlocks = blocksAll.length;
-    const embeddedBlocks = totalBlocks > 0 ? blocksAll.filter((b: any) => b.vec).length : 0;
+    const totalBlocks = plugin.block_collection?.size ?? 0;
+    const embeddedBlocks = plugin.block_collection?.embeddedCount ?? 0;
 
     const notesTotal = plugin.app?.vault?.getMarkdownFiles()?.length ?? 0;
-    const notesEmbedded = plugin.source_collection?.all?.filter((s: any) => s.vec)?.length ?? 0;
+    const notesEmbedded = plugin.block_collection?.embeddedSourceCount ?? 0;
 
     const phase = detectPhase(embeddedBlocks, totalBlocks);
 

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -484,7 +484,7 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
     const collection = this.plugin.source_collection;
 
     const total = collection?.size ?? 0;
-    const embedded = collection?.all?.filter((s: any) => s.vec)?.length ?? 0;
+    const embedded = collection?.embeddedCount ?? 0;
     const pending = Math.max(0, total - embedded);
     const pct = total > 0 ? Math.round((embedded / total) * 100) : 0;
     const activeCtx = this.plugin.getActiveEmbeddingContext?.() ?? null;
@@ -560,7 +560,7 @@ export class SmartConnectionsSettingsTab extends PluginSettingTab {
     if (this.statsGridEl) {
       const collection = this.plugin.source_collection;
       const total = collection?.size ?? 0;
-      const embedded = collection?.all?.filter((s: any) => s.vec)?.length ?? 0;
+      const embedded = collection?.embeddedCount ?? 0;
       const pending = Math.max(0, total - embedded);
       const pct = total > 0 ? Math.round((embedded / total) * 100) : 0;
       this.statsGridEl.empty();

--- a/src/ui/status-bar.ts
+++ b/src/ui/status-bar.ts
@@ -42,9 +42,8 @@ function getVaultTag(plugin: SmartConnectionsPlugin): string {
   const now = Date.now();
   if (now - lastComputeMs < CACHE_TTL_MS && cachedVaultTag) return cachedVaultTag;
 
-  const blocks = plugin.block_collection?.all;
-  const totalBlocks = blocks?.length ?? 0;
-  const embeddedBlocks = blocks?.filter(b => b.vec)?.length ?? 0;
+  const totalBlocks = plugin.block_collection?.size ?? 0;
+  const embeddedBlocks = plugin.block_collection?.embeddedCount ?? 0;
   const vaultPercent = totalBlocks > 0 ? Math.round((embeddedBlocks / totalBlocks) * 100) : 0;
 
   cachedVaultTag = `${embeddedBlocks}/${totalBlocks} (${vaultPercent}%)`;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,7 +21,7 @@ export function errorMessage(e: unknown): string {
  * @returns Similarity score between 0 and 1
  * @throws Error if vectors have different lengths
  */
-export function cos_sim(vector1: number[] = [], vector2: number[] = []): number {
+export function cos_sim(vector1: number[] | Float32Array = [], vector2: number[] | Float32Array = []): number {
   if (vector1.length !== vector2.length) {
     throw new Error('Vectors must have the same length');
   }
@@ -101,7 +101,7 @@ export async function create_hash(text: string): Promise<string> {
  * Compute the element-wise average of one or more vectors.
  * Returns an empty array when no vectors are provided.
  */
-export function average_vectors(vecs: number[][]): number[] {
+export function average_vectors(vecs: (number[] | Float32Array)[]): number[] {
   if (vecs.length === 0) return [];
   const dims = vecs[0].length;
   const out = new Array<number>(dims).fill(0);

--- a/test/connections-view-session.test.ts
+++ b/test/connections-view-session.test.ts
@@ -30,6 +30,7 @@ function createPluginStub() {
       data_dir: '/tmp/blocks',
       all: [] as any[],
       for_source(path: string) { return (this.all as any[]).filter((b: any) => b.source_key === path); },
+      ensure_entity_vector: vi.fn(async () => {}),
       nearest: vi.fn(async () => []),
     },
     open_note: vi.fn(),
@@ -103,6 +104,7 @@ describe('ConnectionsView rendering states', () => {
       vec: [1, 2, 3],
       is_unembedded: false,
       has_embed: () => true,
+      evictVec: vi.fn(),
     };
     plugin.block_collection.all = [embeddedBlock];
     plugin.block_collection.nearest = vi.fn(async () => [

--- a/test/embed-orchestrator-run-state.test.ts
+++ b/test/embed-orchestrator-run-state.test.ts
@@ -33,6 +33,7 @@ function createPlugin() {
     data_dir: '/tmp/sources',
     size: 1,
     all: [],
+    recomputeEmbeddedCount: vi.fn(),
   } as any;
 
   plugin.block_collection = {
@@ -43,6 +44,7 @@ function createPlugin() {
       save: vi.fn(async () => {}),
     },
     data_dir: '/tmp/blocks',
+    recomputeEmbeddedCount: vi.fn(),
   } as any;
 
   plugin.embed_adapter = {

--- a/test/main-embedding-control.test.ts
+++ b/test/main-embedding-control.test.ts
@@ -43,6 +43,7 @@ function createPlugin() {
     data_dir: '/tmp/sources',
     size: 2,
     all: [],
+    recomputeEmbeddedCount: vi.fn(),
   } as any;
 
   plugin.block_collection = {
@@ -54,6 +55,7 @@ function createPlugin() {
       save: vi.fn(async () => {}),
     },
     data_dir: '/tmp/blocks',
+    recomputeEmbeddedCount: vi.fn(),
   } as any;
 
   plugin.embed_adapter = {

--- a/test/pipeline-flow.test.ts
+++ b/test/pipeline-flow.test.ts
@@ -71,12 +71,14 @@ function makePlugin(overrides: Partial<{
     block_collection: {
       all: blocks,
       data_adapter: { save: vi.fn(async () => {}) },
+      recomputeEmbeddedCount: vi.fn(),
     },
     source_collection: {
       all: sources,
       vault: {},
       data_adapter: { save: vi.fn(async () => {}) },
       import_source: vi.fn(async () => {}),
+      recomputeEmbeddedCount: vi.fn(),
     },
     app: {
       vault: {

--- a/test/settings-status-sync.test.ts
+++ b/test/settings-status-sync.test.ts
@@ -72,6 +72,7 @@ function makePlugin(overrides: Record<string, any> = {}): any {
     status_state: 'idle' as 'idle' | 'embedding' | 'error',
     source_collection: {
       size: 10,
+      embeddedCount: 7,
       all: Array.from({ length: 7 }, () => ({ vec: [0.1] })),
     },
     getActiveEmbeddingContext: vi.fn(() => null),
@@ -198,7 +199,7 @@ describe('Settings status sync — terminal event (AC10)', () => {
     const app = makeApp();
     const plugin = makePlugin({
       status_state: 'idle',
-      source_collection: { size: 10, all: fullyEmbedded },
+      source_collection: { size: 10, embeddedCount: 10, all: fullyEmbedded },
     });
     const tab = new SmartConnectionsSettingsTab(app, plugin);
 
@@ -221,7 +222,7 @@ describe('Settings status sync — terminal event (AC10)', () => {
     const fullyEmbedded = Array.from({ length: 5 }, () => ({ vec: [0.1] }));
     const app = makeApp();
     const plugin = makePlugin({
-      source_collection: { size: 5, all: fullyEmbedded },
+      source_collection: { size: 5, embeddedCount: 5, all: fullyEmbedded },
     });
     const tab = new SmartConnectionsSettingsTab(app, plugin);
 
@@ -241,6 +242,7 @@ describe('Settings status sync — live stats update', () => {
     const plugin = makePlugin({
       source_collection: {
         size: 20,
+        embeddedCount: 10,
         all: Array.from({ length: 10 }, () => ({ vec: [0.1] })),
       },
     });
@@ -251,6 +253,7 @@ describe('Settings status sync — live stats update', () => {
     // Simulate progress: 15 of 20 embedded
     plugin.source_collection = {
       size: 20,
+      embeddedCount: 15,
       all: Array.from({ length: 15 }, () => ({ vec: [0.1] })),
     };
     (tab as any).updateEmbeddingStatusOnly();

--- a/test/sqlite-data-adapter-real.test.ts
+++ b/test/sqlite-data-adapter-real.test.ts
@@ -152,7 +152,7 @@ describe('SqliteDataAdapter real sql.js lifecycle', () => {
     ]);
 
     const loaded = await secondAdapter.load_entity_vector('note-a.md#h1', 'test-model');
-    expect(loaded.vec).toEqual([1, 0]);
+    expect(loaded.vec).toEqual(new Float32Array([1, 0]));
     expect(loaded.tokens).toBe(2);
     expect(loaded.meta?.hash).toBe('hash:note-a.md#h1');
 


### PR DESCRIPTION
## Summary
- **Phase 1**: Replace O(n) `.all.filter(b=>b.vec).length` UI scans (88MB/min GC) with event-driven `recomputeEmbeddedCount()` at save/load/clear boundaries
- **Phase 2**: Evict vectors from RAM after SQLite save via `evictVec()`. Migrate `b.vec` truthiness to `b.has_embed()`. On-demand loading for block averaging
- **Phase 3**: `Float32Array` (4B/element) instead of `number[]` (8B/element) for transient vectors
- **Fix "0 notes"**: Use `embeddedSourceCount` (distinct source paths with embedded blocks)

## Design Decision
Event-driven recomputation > increment/decrement counters. Counters had 5+ mutation bypass paths causing permanent desync. `recomputeEmbeddedCount()` is O(n) but only runs at event boundaries (~5s intervals during embedding).

## Test plan
- [x] `pnpm run ci` — 24/24 files, 208/208 tests pass
- [x] QA runtime verification on Ataraxia vault (86,878/113,075 blocks)
- [x] Architect review (2 rounds)
- [x] Critic review (ACCEPT-WITH-RESERVATIONS, gaps addressed)
- [ ] Full 79k-block vault memory measurement via Activity Monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)