### PR TITLE
Reduce startup block imports for large vaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "release:minor": "node scripts/release.mjs minor",
     "release:major": "node scripts/release.mjs major",
     "prepare": "husky",
-    "profile:scaling": "node scripts/profile-scaling.mjs"
+    "profile:scaling": "node scripts/profile-scaling.mjs",
+    "profile:freeze-flows": "node scripts/profile-freeze-flows.mjs",
+    "profile:live-vault": "node scripts/profile-live-vault.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-e2e.sh
+++ b/scripts/check-e2e.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 VAULT="${1:-Test}"
 MAX_WAIT="${2:-300}"
 PLUGIN="open-connections"
-VAULT_PATH="$HOME/Documents/01. Obsidian/$VAULT"
+VAULT_ROOT="${OC_VAULT_ROOT:-$HOME/Documents/01. Obsidian}"
+VAULT_PATH="${OC_VAULT_PATH:-$VAULT_ROOT/$VAULT}"
 PLUGIN_DIR="$VAULT_PATH/.obsidian/plugins/$PLUGIN"
 LOGFILE="artifacts/e2e-check-$(date +%Y%m%d-%H%M%S).log"
 

--- a/scripts/check-embed-speed.sh
+++ b/scripts/check-embed-speed.sh
@@ -6,11 +6,12 @@
 
 set -euo pipefail
 
-VAULT="Test"
+VAULT="${OC_VAULT_NAME:-Test}"
 NUM_BLOCKS="${1:-100}"
 MAX_TIME="${2:-60}"
 PLUGIN="open-connections"
-VAULT_PATH="$HOME/Documents/01. Obsidian/$VAULT"
+VAULT_ROOT="${OC_VAULT_ROOT:-$HOME/Documents/01. Obsidian}"
+VAULT_PATH="${OC_VAULT_PATH:-$VAULT_ROOT/$VAULT}"
 PLUGIN_DIR="$VAULT_PATH/.obsidian/plugins/$PLUGIN"
 LOGFILE="artifacts/embed-speed-$(date +%Y%m%d-%H%M%S).log"
 

--- a/scripts/check-freeze.sh
+++ b/scripts/check-freeze.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 VAULT="${1:-Test}"
 WAIT="${2:-30}"
 PLUGIN="open-connections"
-VAULT_PATH="$HOME/Documents/01. Obsidian/$VAULT"
+VAULT_ROOT="${OC_VAULT_ROOT:-$HOME/Documents/01. Obsidian}"
+VAULT_PATH="${OC_VAULT_PATH:-$VAULT_ROOT/$VAULT}"
 PLUGIN_DIR="$VAULT_PATH/.obsidian/plugins/$PLUGIN"
 
 if [[ ! -d "$VAULT_PATH" ]]; then

--- a/scripts/check-lookup.sh
+++ b/scripts/check-lookup.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 VAULT="${1:-Test}"
 POLL_TIMEOUT="${2:-30}"
 PLUGIN="open-connections"
-VAULT_PATH="$HOME/Documents/01. Obsidian/$VAULT"
+VAULT_ROOT="${OC_VAULT_ROOT:-$HOME/Documents/01. Obsidian}"
+VAULT_PATH="${OC_VAULT_PATH:-$VAULT_ROOT/$VAULT}"
 PLUGIN_DIR="$VAULT_PATH/.obsidian/plugins/$PLUGIN"
 LOGFILE="artifacts/lookup-check-$(date +%Y%m%d-%H%M%S).log"
 

--- a/scripts/profile-flow-report.mjs
+++ b/scripts/profile-flow-report.mjs
@@ -1,0 +1,105 @@
+const STATUS_SEVERITY = {
+  freeze_detected: 4,
+  failed: 3,
+  partial: 2,
+  passed: 1,
+  unknown: 0,
+};
+
+function extractNumber(pattern, text) {
+  const match = text.match(pattern);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+export function classifyScriptRun(stdout, stderr, exitCode) {
+  const combined = `${stdout ?? ''}\n${stderr ?? ''}`;
+  if (/FREEZE_DETECTED|UI FREEZE detected|frozen or not loaded|possible freeze|freeze detected/i.test(combined)) {
+    return 'freeze_detected';
+  }
+  if (/RESULT:\s*PASS/i.test(combined)) return 'passed';
+  if (/RESULT:\s*PARTIAL/i.test(combined)) return 'partial';
+  if (/RESULT:\s*FAIL/i.test(combined) || exitCode !== 0) return 'failed';
+  return 'unknown';
+}
+
+export function summarizeScriptRun(flow, run) {
+  const stdout = run.stdout ?? '';
+  const stderr = run.stderr ?? '';
+  const status = classifyScriptRun(stdout, stderr, run.code ?? 0);
+  const elapsedSeconds = extractNumber(/(?:Completed in|Time:|embed_ready after)\s+(\d+)s/i, stdout);
+  const checks = extractNumber(/Checks:\s*(\d+)\//i, stdout);
+  const queriesWithResults = extractNumber(/Queries with results:\s*(\d+)/i, stdout);
+  const connectionsCount = extractNumber(/Connections:\s*count=(\d+)/i, stdout);
+  const adapterMatch = stdout.match(/Adapter:\s*(.+)$/im) ?? stdout.match(/adapter:\s*(.+)$/im);
+  return {
+    flow,
+    status,
+    severity: STATUS_SEVERITY[status],
+    commandDurationMs: run.durationMs,
+    elapsedSeconds,
+    checks,
+    queriesWithResults,
+    connectionsCount,
+    adapter: adapterMatch?.[1]?.trim() ?? null,
+    exitCode: run.code,
+    timedOut: !!run.timedOut,
+  };
+}
+
+function extractLastJsonBlock(text) {
+  for (let start = text.lastIndexOf('{'); start >= 0; start = text.lastIndexOf('{', start - 1)) {
+    const candidate = text.slice(start).trim();
+    try {
+      JSON.parse(candidate);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export function summarizeScalingRun(run) {
+  const stdout = run.stdout ?? '';
+  const stderr = run.stderr ?? '';
+  const status = classifyScriptRun(stdout, stderr, run.code ?? 0);
+  const parsed = (() => {
+    const jsonBlock = extractLastJsonBlock(stdout);
+    if (!jsonBlock) return null;
+    try {
+      return JSON.parse(jsonBlock);
+    } catch {
+      return null;
+    }
+  })();
+
+  const batches = Array.isArray(parsed?.batches) ? parsed.batches : [];
+  const failedBatches = batches.filter((batch) => batch.status === 'failed').length;
+  const slowestConnectionsViewMs = batches.reduce((max, batch) => {
+    const mean = batch?.timing?.connectionsView?.meanMs ?? 0;
+    return Math.max(max, mean);
+  }, 0);
+
+  return {
+    flow: 'indexing',
+    status,
+    severity: STATUS_SEVERITY[status],
+    commandDurationMs: run.durationMs,
+    artifactPath: parsed?.artifactPath ?? null,
+    batchCount: batches.length,
+    failedBatches,
+    slowestConnectionsViewMs,
+    exitCode: run.code,
+    timedOut: !!run.timedOut,
+  };
+}
+
+export function rankFlowSummaries(summaries) {
+  return [...summaries].sort((left, right) => {
+    if (right.severity !== left.severity) return right.severity - left.severity;
+    const rightCost = right.elapsedSeconds ?? Math.round((right.commandDurationMs ?? 0) / 1000);
+    const leftCost = left.elapsedSeconds ?? Math.round((left.commandDurationMs ?? 0) / 1000);
+    if (rightCost !== leftCost) return rightCost - leftCost;
+    return (right.commandDurationMs ?? 0) - (left.commandDurationMs ?? 0);
+  });
+}

--- a/scripts/profile-freeze-flows.mjs
+++ b/scripts/profile-freeze-flows.mjs
@@ -1,0 +1,152 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import { rankFlowSummaries, summarizeScalingRun, summarizeScriptRun } from './profile-flow-report.mjs';
+
+function parseArgs(argv) {
+  const options = {
+    vault: 'Test',
+    freezeWait: 30,
+    embedBlocks: 100,
+    embedMaxTime: 60,
+    lookupTimeout: 30,
+    e2eMaxWait: 300,
+    counts: '0,1000,3000,6000',
+    artifactDir: resolve(process.cwd(), 'artifacts/freeze-flows'),
+    vaultPath: null,
+    sourceVaultPath: null,
+    testVaultPath: null,
+  };
+
+  for (const arg of argv) {
+    const [key, value] = arg.split('=');
+    if (key === '--vault' && value) options.vault = value;
+    if (key === '--freeze-wait' && value) options.freezeWait = Number.parseInt(value, 10);
+    if (key === '--embed-blocks' && value) options.embedBlocks = Number.parseInt(value, 10);
+    if (key === '--embed-max-time' && value) options.embedMaxTime = Number.parseInt(value, 10);
+    if (key === '--lookup-timeout' && value) options.lookupTimeout = Number.parseInt(value, 10);
+    if (key === '--e2e-max-wait' && value) options.e2eMaxWait = Number.parseInt(value, 10);
+    if (key === '--counts' && value) options.counts = value;
+    if (key === '--artifact-dir' && value) options.artifactDir = resolve(value);
+    if (key === '--vault-path' && value) options.vaultPath = resolve(value);
+    if (key === '--source-vault-path' && value) options.sourceVaultPath = resolve(value);
+    if (key === '--test-vault-path' && value) options.testVaultPath = resolve(value);
+  }
+
+  return options;
+}
+
+function run(command, args, cwd = process.cwd(), env = {}) {
+  return new Promise((resolveRun) => {
+    const startedAt = Date.now();
+    const child = spawn(command, args, {
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+    child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+    child.on('close', (code) => {
+      resolveRun({ code, stdout, stderr, durationMs: Date.now() - startedAt, timedOut: false });
+    });
+  });
+}
+
+function stamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function tail(text, lines = 12) {
+  return (text ?? '').trim().split(/\n/).slice(-lines).join('\n');
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  mkdirSync(options.artifactDir, { recursive: true });
+
+  const vaultEnv = options.vaultPath ? { OC_VAULT_PATH: options.vaultPath } : {};
+  const commands = [
+    {
+      flow: 'boot',
+      command: 'bash',
+      args: ['scripts/check-freeze.sh', options.vault, String(options.freezeWait)],
+      env: vaultEnv,
+      summarize: (run) => summarizeScriptRun('boot', run),
+    },
+    {
+      flow: 'reembed',
+      command: 'bash',
+      args: ['scripts/check-embed-speed.sh', String(options.embedBlocks), String(options.embedMaxTime)],
+      env: { ...vaultEnv, OC_VAULT_NAME: options.vault },
+      summarize: (run) => summarizeScriptRun('reembed', run),
+    },
+    {
+      flow: 'lookup',
+      command: 'bash',
+      args: ['scripts/check-lookup.sh', options.vault, String(options.lookupTimeout)],
+      env: vaultEnv,
+      summarize: (run) => summarizeScriptRun('lookup', run),
+    },
+    {
+      flow: 'block-import',
+      command: 'bash',
+      args: ['scripts/check-e2e.sh', options.vault, String(options.e2eMaxWait)],
+      env: vaultEnv,
+      summarize: (run) => summarizeScriptRun('block-import', run),
+    },
+    {
+      flow: 'indexing',
+      command: 'node',
+      args: [
+        'scripts/profile-scaling.mjs',
+        `--vault=${options.vault}`,
+        `--counts=${options.counts}`,
+        `--artifact-dir=${options.artifactDir}/scaling`,
+        ...(options.sourceVaultPath ? [`--source=${options.sourceVaultPath}`] : []),
+        ...(options.testVaultPath ? [`--test-vault-path=${options.testVaultPath}`] : []),
+      ],
+      env: {},
+      summarize: summarizeScalingRun,
+    },
+  ];
+
+  const runs = [];
+  for (const step of commands) {
+    const runResult = await run(step.command, step.args, process.cwd(), step.env);
+    runs.push({
+      flow: step.flow,
+      summary: step.summarize(runResult),
+      stdoutTail: tail(runResult.stdout),
+      stderrTail: tail(runResult.stderr),
+    });
+  }
+
+  const ranking = rankFlowSummaries(runs.map((entry) => entry.summary));
+  const artifact = {
+    startedAt: new Date().toISOString(),
+    options,
+    ranking,
+    runs: runs.map(({ flow, summary, stdoutTail, stderrTail }) => ({
+      flow,
+      summary,
+      stdoutTail,
+      stderrTail,
+    })),
+  };
+
+  const artifactPath = resolve(options.artifactDir, `${stamp()}-freeze-flows.json`);
+  writeFileSync(artifactPath, JSON.stringify(artifact, null, 2));
+  console.log(JSON.stringify({ artifactPath, ranking, flows: runs.map((entry) => entry.summary) }, null, 2));
+
+  if (ranking[0]?.status !== 'passed') {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/profile-live-vault.mjs
+++ b/scripts/profile-live-vault.mjs
@@ -1,0 +1,103 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_ARTIFACT_DIR = resolve(process.cwd(), 'artifacts/live-vault-profiles');
+
+function parseArgs(argv) {
+  const options = {
+    vault: 'Ataraxia',
+    query: 'productivity',
+    artifactDir: DEFAULT_ARTIFACT_DIR,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+  };
+
+  for (const arg of argv) {
+    const [key, value] = arg.split('=');
+    if (key === '--vault' && value) options.vault = value;
+    if (key === '--query' && value) options.query = value;
+    if (key === '--artifact-dir' && value) options.artifactDir = resolve(value);
+    if (key === '--timeout-ms' && value) options.timeoutMs = Number.parseInt(value, 10);
+  }
+
+  return options;
+}
+
+function stamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function runObsidian(vault, args, timeoutMs) {
+  return new Promise((resolveRun) => {
+    const startedAt = Date.now();
+    const child = spawn('obsidian', [`vault=${vault}`, ...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+    child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+    child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      resolveRun({ code, signal, stdout, stderr, timedOut, durationMs: Date.now() - startedAt });
+    });
+  });
+}
+
+function parseEval(stdout) {
+  const line = stdout.split('\n').map((value) => value.trim()).find((value) => value.startsWith('=> '));
+  if (!line) return null;
+  const payload = line.slice(3);
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return payload;
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  mkdirSync(options.artifactDir, { recursive: true });
+
+  const runtime = await runObsidian(options.vault, ['eval', `code=(function(){var p=app.plugins.plugins["open-connections"];return JSON.stringify({ready:!!p?.ready,embedReady:!!p?.embed_ready,noteCount:app.vault.getMarkdownFiles().length,sourceCount:p?.source_collection?.size??null,embeddedSourceCount:p?.source_collection?.embeddedCount??null,blockCount:p?.block_collection?.size??null,embeddedBlockCount:p?.block_collection?.embeddedCount??null,runtimeState:p?.getEmbedRuntimeState?.()??null,profilingState:p?.getEmbedProfilingState?.()??null,protoProps:p?Object.getOwnPropertyNames(Object.getPrototypeOf(p)).filter(function(k){return k.indexOf('Embed')>=0||k.indexOf('embed')>=0||k.indexOf('Runtime')>=0||k.indexOf('Profil')>=0;}):[],commandIds:Object.keys(app.commands.commands).filter(function(k){return k.indexOf('open-connections')>=0;}),leafCounts:{connections:app.workspace.getLeavesOfType('open-connections-view').length,lookup:app.workspace.getLeavesOfType('open-connections-lookup').length}});})()`], options.timeoutMs);
+
+  const connectionsView = await runObsidian(options.vault, ['command', 'id=open-connections:connections-view'], options.timeoutMs);
+  const lookupView = await runObsidian(options.vault, ['command', 'id=open-connections:open-lookup-view'], options.timeoutMs);
+  const lookupSearch = await runObsidian(options.vault, ['eval', `code=(async function(){app.commands.executeCommandById("open-connections:open-lookup-view");await new Promise(function(resolve){setTimeout(resolve,250);});var leaf=app.workspace.getLeavesOfType("open-connections-lookup")[0];if(!leaf)return JSON.stringify({error:"lookup-view-missing"});var view=leaf.view;view.searchInput.value=${JSON.stringify(options.query)};view.performSearch(${JSON.stringify(options.query)});await new Promise(function(resolve){setTimeout(resolve,2000);});return JSON.stringify({query:${JSON.stringify(options.query)},resultCount:view.containerEl.querySelectorAll(".osc-lookup-result").length,leafCount:app.workspace.getLeavesOfType("open-connections-lookup").length});})()`], options.timeoutMs);
+
+  const artifact = {
+    startedAt: new Date().toISOString(),
+    options,
+    runtime: {
+      ...runtime,
+      parsed: parseEval(runtime.stdout),
+    },
+    connectionsView,
+    lookupView,
+    lookupSearch: {
+      ...lookupSearch,
+      parsed: parseEval(lookupSearch.stdout),
+    },
+  };
+
+  const artifactPath = resolve(options.artifactDir, `${stamp()}-${options.vault.toLowerCase()}-live-profile.json`);
+  writeFileSync(artifactPath, JSON.stringify(artifact, null, 2));
+  console.log(JSON.stringify({
+    artifactPath,
+    runtime: artifact.runtime.parsed,
+    connectionsViewMs: connectionsView.durationMs,
+    lookupViewMs: lookupView.durationMs,
+    lookupSearch: artifact.lookupSearch.parsed,
+  }, null, 2));
+
+  if (runtime.timedOut || lookupSearch.timedOut) process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exit(1);
+});

--- a/src/ui/collection-block-import.ts
+++ b/src/ui/collection-block-import.ts
@@ -9,25 +9,50 @@ import type SmartConnectionsPlugin from '../main';
 const SAVE_INTERVAL = 50;
 const YIELD_MS = 10;
 
+export interface BlockImportResult {
+  importedCount: number;
+  remainingCount: number;
+  totalCount: number;
+}
+
 /**
  * Import blocks for sources that have no blocks yet.
  * Processes one file at a time with yields to keep the UI responsive.
  */
-export async function importBlocksChunked(plugin: SmartConnectionsPlugin): Promise<void> {
-  if (!plugin.source_collection || !plugin.block_collection) return;
+export async function importBlocksChunked(
+  plugin: SmartConnectionsPlugin,
+  options: { limit?: number } = {},
+): Promise<BlockImportResult> {
+  if (!plugin.source_collection || !plugin.block_collection) {
+    return { importedCount: 0, remainingCount: 0, totalCount: 0 };
+  }
 
   const sources = plugin.source_collection.all.filter(
     (source) => plugin.block_collection!.for_source(source.key).length === 0,
   );
 
-  if (sources.length === 0) return;
+  if (sources.length === 0) {
+    return { importedCount: 0, remainingCount: 0, totalCount: 0 };
+  }
 
-  const total = sources.length;
-  plugin.logger.debug(`[SC] Block import: starting ${total} sources`);
+  const totalCount = sources.length;
+  const limit = options.limit && options.limit > 0
+    ? Math.min(options.limit, totalCount)
+    : totalCount;
+  const selectedSources = sources.slice(0, limit);
+  plugin.logger.debug(
+    `[SC] Block import: starting ${selectedSources.length}/${totalCount} sources`,
+  );
 
-  let processed = 0;
-  for (const source of sources) {
-    if (plugin._unloading) return;
+  let importedCount = 0;
+  for (const source of selectedSources) {
+    if (plugin._unloading) {
+      return {
+        importedCount,
+        remainingCount: Math.max(totalCount - importedCount, 0),
+        totalCount,
+      };
+    }
 
     try {
       await plugin.block_collection.import_source_blocks(source);
@@ -35,16 +60,24 @@ export async function importBlocksChunked(plugin: SmartConnectionsPlugin): Promi
       plugin.logger.warn(`[SC] Block import failed for ${source.key}:`, error as Record<string, unknown>);
     }
 
-    processed++;
+    importedCount++;
 
-    if (processed % SAVE_INTERVAL === 0) {
+    if (importedCount % SAVE_INTERVAL === 0) {
       await plugin.block_collection.data_adapter.save();
-      plugin.logger.debug(`[SC] Block import: ${processed}/${total}`);
+      plugin.logger.debug(`[SC] Block import: ${importedCount}/${totalCount}`);
     }
 
     await new Promise((resolve) => setTimeout(resolve, YIELD_MS));
   }
 
   await plugin.block_collection.data_adapter.save();
-  plugin.logger.debug(`[SC] Block import complete: ${total} sources`);
+  plugin.logger.debug(
+    `[SC] Block import complete: imported ${importedCount}/${totalCount} sources`,
+  );
+
+  return {
+    importedCount,
+    remainingCount: Math.max(totalCount - importedCount, 0),
+    totalCount,
+  };
 }

--- a/src/ui/plugin-initialization.ts
+++ b/src/ui/plugin-initialization.ts
@@ -14,6 +14,8 @@ import { isCurrentLifecycle } from './plugin-lifecycle';
 import { setupStatusBar } from './status-bar';
 import { handleNewUser, loadUserState } from './user-state';
 
+const STARTUP_BACKGROUND_IMPORT_LIMIT = 50;
+
 async function runInitStep(
   plugin: SmartConnectionsPlugin,
   lifecycle: number,
@@ -156,8 +158,15 @@ export async function initializeEmbedding(
           if (plugin._unloading || !isCurrentLifecycle(plugin, lifecycle)) return;
           plugin.logger.debug('[SC][Init] ▶ Phase 3: Background block import');
           beginEmbedProfilingStage(plugin, 'init:background-import');
-          await importBlocksChunked(plugin);
+          const importResult = await importBlocksChunked(plugin, {
+            limit: STARTUP_BACKGROUND_IMPORT_LIMIT,
+          });
           if (plugin._unloading || !isCurrentLifecycle(plugin, lifecycle)) return;
+          if (importResult.remainingCount > 0) {
+            plugin.logger.info(
+              `[SC][Init] Phase 3 deferred ${importResult.remainingCount} sources to on-demand import`,
+            );
+          }
           const queued = queueUnembeddedEntities(plugin);
           if (queued > 0 && plugin.embedding_pipeline) {
             plugin.logger.debug(`[SC][Init] Phase 3: ${queued} blocks to embed`);

--- a/test/collection-block-import.test.ts
+++ b/test/collection-block-import.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { importBlocksChunked } from '../src/ui/collection-block-import';
+
+function makeSource(key: string) {
+  return { key };
+}
+
+describe('importBlocksChunked', () => {
+  it('caps startup imports and reports remaining backlog', async () => {
+    const sources = Array.from({ length: 120 }, (_, index) => makeSource(`note-${index}.md`));
+    const importSourceBlocks = vi.fn(async () => {});
+    const save = vi.fn(async () => {});
+
+    const plugin = {
+      _unloading: false,
+      logger: {
+        debug: vi.fn(),
+        warn: vi.fn(),
+      },
+      source_collection: {
+        all: sources,
+      },
+      block_collection: {
+        for_source: vi.fn(() => []),
+        import_source_blocks: importSourceBlocks,
+        data_adapter: { save },
+      },
+    } as never;
+
+    const result = await importBlocksChunked(plugin, { limit: 50 });
+
+    expect(importSourceBlocks).toHaveBeenCalledTimes(50);
+    expect(result).toEqual({
+      importedCount: 50,
+      remainingCount: 70,
+      totalCount: 120,
+    });
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/profile-flow-report.test.ts
+++ b/test/profile-flow-report.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyScriptRun,
+  rankFlowSummaries,
+  summarizeScalingRun,
+  summarizeScriptRun,
+} from '../scripts/profile-flow-report.mjs';
+
+describe('profile flow report helpers', () => {
+  it('classifies freeze output ahead of generic failure', () => {
+    expect(classifyScriptRun('FREEZE_DETECTED\nRESULT: FAIL', '', 1)).toBe('freeze_detected');
+    expect(classifyScriptRun('RESULT: PASS', '', 0)).toBe('passed');
+    expect(classifyScriptRun('RESULT: PARTIAL', '', 1)).toBe('partial');
+  });
+
+  it('extracts script summary fields from stdout', () => {
+    const summary = summarizeScriptRun('reembed', {
+      stdout: 'Completed in 18s\nAdapter: local-transformers\nChecks: 3/3 passed\nRESULT: PASS',
+      stderr: '',
+      code: 0,
+      durationMs: 18123,
+      timedOut: false,
+    });
+
+    expect(summary).toMatchObject({
+      flow: 'reembed',
+      status: 'passed',
+      elapsedSeconds: 18,
+      adapter: 'local-transformers',
+      checks: 3,
+    });
+  });
+
+  it('summarizes scaling output from the final JSON block', () => {
+    const run = {
+      stdout: [
+        'noise',
+        JSON.stringify({
+          artifactPath: 'artifacts/scaling.json',
+          batches: [
+            { status: 'passed', timing: { connectionsView: { meanMs: 120 } } },
+            { status: 'failed', timing: { connectionsView: { meanMs: 240 } } },
+          ],
+        }, null, 2),
+      ].join('\n'),
+      stderr: '',
+      code: 1,
+      durationMs: 5000,
+      timedOut: false,
+    };
+
+    expect(summarizeScalingRun(run)).toMatchObject({
+      flow: 'indexing',
+      status: 'failed',
+      artifactPath: 'artifacts/scaling.json',
+      batchCount: 2,
+      failedBatches: 1,
+      slowestConnectionsViewMs: 240,
+    });
+  });
+
+  it('ranks worse status ahead of slower passing runs', () => {
+    const ranked = rankFlowSummaries([
+      { flow: 'lookup', status: 'passed', severity: 1, commandDurationMs: 9000, elapsedSeconds: 9 },
+      { flow: 'boot', status: 'freeze_detected', severity: 4, commandDurationMs: 3000, elapsedSeconds: 3 },
+      { flow: 'reembed', status: 'failed', severity: 3, commandDurationMs: 11000, elapsedSeconds: 11 },
+    ]);
+
+    expect(ranked.map((item) => item.flow)).toEqual(['boot', 'reembed', 'lookup']);
+  });
+});


### PR DESCRIPTION
## Summary
- cap startup Phase 3 block imports to a small batch instead of importing every missing source on load
- defer the remaining source backlog to the existing on-demand import path used by Connections View
- add a focused regression test plus a live-vault profiling helper for Ataraxia evidence gathering

## Why
Profiling on Ataraxia showed the main startup hotspot was `init:background-import`, not command dispatch.

Evidence gathered:
- before: `init:background-import` ~= **50,128ms**
- after: `init:background-import` ~= **1,320ms**
- reduction: **97.4%**
- command dispatch remained ~200-230ms, so the long stall was in startup block import work

Artifacts referenced locally during verification:
- `artifacts/live-vault-profiles/ataraxia-profiling-poll.json`
- `artifacts/live-vault-profiles/ataraxia-profiling-poll-after-cap-followup.json`
- `artifacts/live-vault-profiles/ataraxia-background-import-comparison.json`

## Verification
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm exec eslint src/ui/collection-block-import.ts src/ui/plugin-initialization.ts`
- `pnpm exec eslint test/collection-block-import.test.ts test/profile-flow-report.test.ts`
- `pnpm exec vitest run test/collection-block-import.test.ts`
- `pnpm exec vitest run test/profile-flow-report.test.ts`
- live-vault profiling before/after on Ataraxia

## Notes
- this does **not** change embedding quality/models, ranking logic, provider API surface, or UI design
- Test vault bootstrap is still unreliable and remains a separate follow-up concern
- larger lazy-loading / structural follow-up work should stay in a separate issue/PR

Related: #74