### PR TITLE
Implement Slice 1 reader seam and SWR connections cache

### DIFF
--- a/docs/superpowers/plans/2026-04-20-slice-1-dip-seam-then-swr.md
+++ b/docs/superpowers/plans/2026-04-20-slice-1-dip-seam-then-swr.md
@@ -1,0 +1,731 @@
+# Slice 1 — DIP Seam, then SWR Results Cache — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land a narrow `ConnectionsReader` port (DIP) in the view/state layer, then TDD-build a Stale-While-Revalidate results cache on top of it — without touching the write-side (Slice 2).
+
+**Architecture:** Three new seams — a Reader port in `src/types/`, a pure `ConnectionsResultCache` + pure `decideRender` in `src/domain/connections/`, and a composition-root adapter in `src/ui/`. The UI view consumes the Reader via its constructor, the render pipeline consults the cache, and the existing workspace event bus drives revalidation.
+
+**Tech Stack:** TypeScript, Vitest + jsdom, ESLint flat-config layer walls, esbuild, Obsidian plugin runtime.
+
+**Spec:** `open-connections/docs/superpowers/specs/2026-04-20-slice-1-dip-seam-then-swr-spec.md`
+
+**Clarified execution rule (2026-04-20 deep-interview).**
+- Default to completing the current spec, but only through a **tests-first / characterization-first** sequence.
+- When evidence shows a spec item is not causally tied to the screen-transition freeze and fixing it now would increase behavior risk, prefer **freeze reduction + behavior preservation first** and defer that item explicitly.
+- Broaden cleanup only when it directly enables the tests or the freeze-focused refactor.
+- Do not touch `manifest.json`, versioning, release scripts, or release workflow concerns in this flow.
+
+---
+
+## Phase 0 — Preparatory Exploration (single subagent, read-only)
+
+### Task 0.1: Finalize the Reader surface by grepping every ConnectionsView plugin read
+
+**Files:**
+- Read-only (no writes)
+
+- [ ] **Step 1: Dispatch `Explore` subagent**
+
+```
+Agent(subagent_type="Explore", thoroughness="very thorough",
+  description="Finalize ConnectionsReader surface",
+  prompt="""
+Grep open-connections/src/ui/ConnectionsView.ts and src/ui/connections-view-state.ts for every
+read of `view.plugin.*` or `this.plugin.*`. Produce an exhaustive list grouped by:
+  (A) block/source data lookups
+  (B) plugin-lifecycle flags (ready, embed_ready, status_state, _discovering)
+  (C) embedding-kernel state (getEmbedRuntimeState, _embed_state, _search_embed_model.fingerprint)
+  (D) pending-import tracking (pendingReImportPaths)
+For each call, give file:line and the exact expression. Then propose the MINIMAL ConnectionsReader
+interface that covers only the READ paths in those two files (ignore writes). Flag any plugin field
+that is NOT a read (i.e. a method call with side effects) so we keep it OUT of Slice 1.
+Output ≤ 300 words + a typed interface block.
+"""
+)
+```
+
+- [ ] **Step 2: Reconcile subagent output with spec's Reader sketch**
+
+Confirm `ConnectionsReader` in the spec matches or strictly widens the subagent's proposal. If the subagent found a READ not in the sketch, add it to the spec (update §"Code Style") before proceeding. If the subagent found a WRITE we missed, flag it — it belongs in Slice 2.
+
+- [ ] **Step 3: Commit the spec update only (if any)**
+
+```bash
+git add open-connections/docs/superpowers/specs/2026-04-20-slice-1-dip-seam-then-swr-spec.md
+git commit -m "docs(spec): finalize ConnectionsReader surface from Phase-0 recon"
+```
+
+---
+
+## Phase A — Seam Introduction (Reader port → adapter → view wiring)
+
+### Task A.1: Define `ConnectionsReader` port
+
+**Files:**
+- Create: `open-connections/src/types/connections-reader.ts`
+- Modify: `open-connections/src/types/obsidian-shims.ts` (add `EmbeddingBlockLike`, `EmbeddingSourceLike` if not present; keep ≤ 200 LOC)
+- Test: `open-connections/test/connections-reader.types.test.ts`
+
+- [ ] **Step 1: Write the failing type-level test**
+
+```ts
+// test/connections-reader.types.test.ts
+import { describe, it, expectTypeOf } from 'vitest';
+import type { ConnectionsReader } from '../src/types/connections-reader';
+
+describe('ConnectionsReader port', () => {
+  it('exposes read-only methods and no mutators', () => {
+    expectTypeOf<ConnectionsReader['isReady']>().toEqualTypeOf<() => boolean>();
+    expectTypeOf<ConnectionsReader['hasPendingReImport']>().toEqualTypeOf<(p: string) => boolean>();
+    // @ts-expect-error — mutators must not exist on the reader
+    type NoMutator = ConnectionsReader['importSourceBlocks'];
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run test/connections-reader.types.test.ts`
+Expected: FAIL — cannot resolve `../src/types/connections-reader`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/types/connections-reader.ts
+import type { ParsedEmbedRuntimeState, EmbedStatePhase } from './embed-runtime';
+import type { EmbeddingBlockLike, EmbeddingSourceLike } from './obsidian-shims';
+
+export interface ConnectionsReader {
+  isReady(): boolean;
+  isEmbedReady(): boolean;
+  getStatusState(): string;
+  hasPendingReImport(path: string): boolean;
+  getBlocksForSource(path: string): EmbeddingBlockLike[];
+  getSource(path: string): EmbeddingSourceLike | null;
+  ensureBlocksForSource(path: string): Promise<readonly EmbeddingBlockLike[]>;
+  getConnectionsForSource(path: string, limit?: number): Promise<readonly ConnectionResult[]>;
+  getEmbedRuntimeState(): ParsedEmbedRuntimeState | null;
+  getSearchModelFingerprint(): string | null;
+  getKernelPhase(): EmbedStatePhase;   // 'idle' | 'running' | 'error' — SWR input
+  isDiscovering(): boolean;            // replaces ConnectionsView.ts:117 plugin._discovering read
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run test/connections-reader.types.test.ts && pnpm run typecheck && pnpm run lint`
+Expected: all green. No `obsidian` import added to `src/types/**`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/connections-reader.ts src/types/obsidian-shims.ts test/connections-reader.types.test.ts
+git commit -m "feat(types): add ConnectionsReader port (DIP seam, no obsidian import)"
+```
+
+### Task A.2: Implement `connections-reader-adapter.ts` in the composition root
+
+**Files:**
+- Create: `open-connections/src/ui/connections-reader-adapter.ts`
+- Test: `open-connections/test/connections-reader-adapter.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/connections-reader-adapter.test.ts
+import { describe, it, expect } from 'vitest';
+import { createConnectionsReader } from '../src/ui/connections-reader-adapter';
+
+describe('createConnectionsReader', () => {
+  const fakePlugin = {
+    ready: true,
+    embed_ready: false,
+    status_state: 'ok',
+    pendingReImportPaths: new Set(['a.md']),
+    block_collection: { for_source: (p: string) => (p === 'x.md' ? [{ has_embed: () => true }] : []) },
+    source_collection: { get: (p: string) => (p === 'x.md' ? { path: 'x.md' } : null) },
+    getEmbedRuntimeState: () => ({ serving: { kind: 'ready' } }),
+    _search_embed_model: { fingerprint: 'fp-1' },
+  } as any;
+
+  it('exposes plugin reads through the Reader surface', () => {
+    const r = createConnectionsReader(fakePlugin);
+    expect(r.isReady()).toBe(true);
+    expect(r.isEmbedReady()).toBe(false);
+    expect(r.hasPendingReImport('a.md')).toBe(true);
+    expect(r.hasPendingReImport('b.md')).toBe(false);
+    expect(r.getBlocksForSource('x.md')).toHaveLength(1);
+    expect(r.getSource('x.md')?.path).toBe('x.md');
+    expect(r.getEmbedRuntimeState()?.serving.kind).toBe('ready');
+    expect(r.getSearchModelFingerprint()).toBe('fp-1');
+  });
+
+  it('returns null when optional fields are absent', () => {
+    const r = createConnectionsReader({ ready: false } as any);
+    expect(r.isReady()).toBe(false);
+    expect(r.getSource('y.md')).toBeNull();
+    expect(r.getEmbedRuntimeState()).toBeNull();
+    expect(r.getSearchModelFingerprint()).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run test/connections-reader-adapter.test.ts`
+Expected: FAIL — `createConnectionsReader` is not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/ui/connections-reader-adapter.ts
+import type SmartConnectionsPlugin from '../main';
+import type { ConnectionsReader } from '../types/connections-reader';
+
+export function createConnectionsReader(plugin: SmartConnectionsPlugin): ConnectionsReader {
+  return {
+    isReady: () => Boolean(plugin.ready),
+    isEmbedReady: () => Boolean(plugin.embed_ready),
+    getStatusState: () => plugin.status_state ?? '',
+    hasPendingReImport: (p) => plugin.pendingReImportPaths?.has(p) ?? false,
+    getBlocksForSource: (p) => plugin.block_collection?.for_source(p) ?? [],
+    getSource: (p) => plugin.source_collection?.get(p) ?? null,
+    getEmbedRuntimeState: () => plugin.getEmbedRuntimeState?.() ?? null,
+    getSearchModelFingerprint: () => plugin._search_embed_model?.fingerprint ?? null,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run test/connections-reader-adapter.test.ts && pnpm run typecheck && pnpm run lint`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/connections-reader-adapter.ts test/connections-reader-adapter.test.ts
+git commit -m "feat(ui): ConnectionsReader adapter at composition root"
+```
+
+### Task A.3: Reroute `deriveConnectionsViewState` through the Reader
+
+**Files:**
+- Modify: `open-connections/src/ui/connections-view-state.ts:21-70` (replace `view.plugin.*` reads; keep writes untouched)
+- Test: `open-connections/test/connections-view-state.reader-injection.test.ts` (new)
+
+> The write-side calls (`import_source_blocks`, `data_adapter.save`, `autoQueueBlockEmbedding`) stay on `view.plugin.*` in this task. They will leave the view in Slice 2.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/connections-view-state.reader-injection.test.ts
+import { describe, it, expect } from 'vitest';
+import { deriveConnectionsViewState } from '../src/ui/connections-view-state';
+import type { ConnectionsReader } from '../src/types/connections-reader';
+
+function makeReader(overrides: Partial<ConnectionsReader> = {}): ConnectionsReader {
+  return {
+    isReady: () => true, isEmbedReady: () => true, getStatusState: () => 'ok',
+    hasPendingReImport: () => false,
+    getBlocksForSource: () => [],
+    getSource: () => null,
+    getEmbedRuntimeState: () => null,
+    getSearchModelFingerprint: () => 'fp-1',
+    ...overrides,
+  };
+}
+
+describe('deriveConnectionsViewState — reader-driven reads', () => {
+  it('returns plugin_loading when reader.isReady() is false', async () => {
+    const view: any = { plugin: { block_collection: {} }, reader: makeReader({ isReady: () => false }) };
+    const state = await deriveConnectionsViewState(view, 'a.md');
+    expect(state.type).toBe('plugin_loading');
+  });
+
+  it('returns pending_import when reader reports pending', async () => {
+    const view: any = { plugin: { block_collection: { for_source: () => [] } }, reader: makeReader({ hasPendingReImport: () => true }) };
+    const state = await deriveConnectionsViewState(view, 'a.md');
+    expect(state).toEqual({ type: 'pending_import', path: 'a.md' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run test/connections-view-state.reader-injection.test.ts`
+Expected: FAIL — `view.reader` is undefined; function still reads `view.plugin.ready`.
+
+- [ ] **Step 3: Modify `deriveConnectionsViewState` minimally**
+
+Only swap the READ paths to `view.reader.*`. Keep `view.plugin.block_collection.import_source_blocks(...)` and `view.plugin.block_collection.data_adapter.save()` lines exactly as-is (Slice 2 work).
+
+`view.plugin.block_collection` is **not** allowed to remain in the steady-state render path just because the write-side calls are temporarily preserved here. In particular, `getBlockConnections(view.plugin.block_collection, ...)` must be eliminated behind a read/query seam before Slice 1 sign-off, because the spec's Success Criterion 1 forbids passing `view.plugin.block_collection` through the render path.
+
+```ts
+// src/ui/connections-view-state.ts (excerpt)
+export async function deriveConnectionsViewState(view: ConnectionsView, targetPath: string): Promise<ViewState> {
+  const r = view.reader;
+  if (!r.isReady()) return { type: 'plugin_loading' };
+
+  let allFileBlocks = r.getBlocksForSource(targetPath);
+  if (allFileBlocks.length === 0) {
+    if (r.hasPendingReImport(targetPath)) return { type: 'pending_import', path: targetPath };
+    const source = r.getSource(targetPath);
+    if (source) {
+      // writes stay on plugin for Slice 1 — Slice 2 will extract
+      await view.plugin.block_collection.import_source_blocks(source);
+      await view.plugin.block_collection.data_adapter.save();
+      allFileBlocks = r.getBlocksForSource(targetPath);
+    }
+    if (allFileBlocks.length === 0) return { type: 'note_too_short' };
+  }
+  /* ...remaining branches use r.getEmbedRuntimeState(), r.getStatusState(), r.isEmbedReady()... */
+}
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `pnpm run typecheck && pnpm run lint && pnpm vitest run`
+Expected: all green, including the older `connections-view-state.test.ts` (may require injecting a reader into its fixture — fix the fixture, don't weaken the test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/connections-view-state.ts test/connections-view-state.reader-injection.test.ts test/**/*.ts
+git commit -m "refactor(ui): route deriveConnectionsViewState reads through ConnectionsReader"
+```
+
+### Task A.4: Inject Reader into `ConnectionsView` and wire `main.ts`
+
+**Files:**
+- Modify: `open-connections/src/ui/ConnectionsView.ts:33-53` (constructor + field)
+- Modify: `open-connections/src/main.ts` (registerView factory)
+- Test: `open-connections/test/connections-view.wiring.test.ts` (new, tiny)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/connections-view.wiring.test.ts
+import { describe, it, expect } from 'vitest';
+import { ConnectionsView } from '../src/ui/ConnectionsView';
+
+describe('ConnectionsView constructor wiring', () => {
+  it('accepts a ConnectionsReader and exposes it as view.reader', () => {
+    const leaf: any = { view: null }; const plugin: any = { ready: true };
+    const reader: any = { isReady: () => true };
+    const view = new ConnectionsView(leaf, plugin, reader);
+    expect((view as any).reader).toBe(reader);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run test/connections-view.wiring.test.ts`
+Expected: FAIL — constructor takes 2 args.
+
+- [ ] **Step 3: Modify ConnectionsView and main.ts**
+
+```ts
+// src/ui/ConnectionsView.ts (excerpt)
+constructor(leaf: WorkspaceLeaf, plugin: SmartConnectionsPlugin, reader: ConnectionsReader) {
+  super(leaf); this.plugin = plugin; this.reader = reader; this.navigation = false; loadConnectionsSession(this);
+}
+// ...
+reader: ConnectionsReader;
+```
+
+```ts
+// src/main.ts (excerpt where registerView is called)
+this.registerView(CONNECTIONS_VIEW_TYPE, (leaf) => new ConnectionsView(leaf, this, createConnectionsReader(this)));
+```
+
+- [ ] **Step 4: Run full CI**
+
+Run: `pnpm run ci`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/ConnectionsView.ts src/main.ts test/connections-view.wiring.test.ts
+git commit -m "feat(ui): inject ConnectionsReader into ConnectionsView via constructor"
+```
+
+### Task A.5: Phase-A review gate
+
+- [ ] **Step 1: Dispatch `code-reviewer` subagent**
+
+```
+Agent(subagent_type="oh-my-claudecode:code-reviewer",
+  description="Phase A seam review",
+  prompt="Review commits from 'add ConnectionsReader port' through 'inject ConnectionsReader'. Check: (1) src/types/connections-reader.ts has zero obsidian imports; (2) ConnectionsView constructor signature change is honored at every call site; (3) tests stub the reader and do NOT stub the whole plugin; (4) no write-side calls were moved; (5) rules.md R3/R4 respected per file. Report pass/fail with specific file:line evidence."
+)
+```
+
+- [ ] **Step 2: Resolve findings, then tag**
+
+If review passes: `git tag slice-1-phase-a-done` (local tag only, do NOT push).
+
+---
+
+## Phase B — Characterization Tests (capture existing render behavior)
+
+> Goal: before we alter render logic in Phase C/D, lock down today's observable behavior with tests that run against the new Reader-injected view. Each test below runs the view's existing `renderView(path)` and asserts on DOM + event state.
+
+### Task B.1: Characterize each `ViewState` branch
+
+**Files:**
+- Test: `open-connections/test/connections-view.characterization.test.ts`
+
+- [ ] **Step 1: Write the failing characterization suite (one `it` per ViewState variant)**
+
+```ts
+// test/connections-view.characterization.test.ts (excerpt — pattern repeats for each variant)
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ConnectionsView } from '../src/ui/ConnectionsView';
+import type { ConnectionsReader } from '../src/types/connections-reader';
+
+function mountView(reader: ConnectionsReader, plugin: any = {}) {
+  const leaf: any = { view: null, containerEl: document.createElement('div') };
+  leaf.containerEl.appendChild(document.createElement('div'));
+  leaf.containerEl.appendChild(document.createElement('div'));
+  const view = new ConnectionsView(leaf, plugin, reader);
+  (view as any).container = leaf.containerEl.children[1];
+  return view;
+}
+
+describe('ConnectionsView characterization', () => {
+  beforeEach(() => { /* reset jsdom */ });
+
+  it('shows note_too_short empty message when no blocks and no source', async () => {
+    const reader = /* …stub that returns [] for getBlocksForSource and null for getSource… */;
+    const view = mountView(reader);
+    await view.renderView('a.md');
+    expect((view as any).container.textContent).toMatch(/too short/i);
+  });
+
+  it('shows loading when reader.isEmbedReady() is false and no blocks embedded', async () => { /* … */ });
+  it('renders results container when reader yields embedded blocks', async () => { /* … */ });
+  it('shows pending_import loading when reader.hasPendingReImport() is true', async () => { /* … */ });
+  it('shows model_error when getStatusState is "error"', async () => { /* … */ });
+});
+```
+
+- [ ] **Step 2: Run to verify characterization passes on current behavior**
+
+Run: `pnpm vitest run test/connections-view.characterization.test.ts`
+Expected: PASS. If any fail, the reader wiring from Phase A is wrong — STOP and fix Phase A before continuing.
+
+- [ ] **Step 3: Commit characterization baseline**
+
+```bash
+git add test/connections-view.characterization.test.ts
+git commit -m "test(ui): characterize ConnectionsView render branches (pre-SWR baseline)"
+```
+
+### Task B.2: Phase-B review gate
+
+- [ ] **Step 1: Dispatch `verifier` subagent**
+
+```
+Agent(subagent_type="oh-my-claudecode:verifier",
+  description="Phase B characterization coverage",
+  prompt="Run `pnpm vitest run test/connections-view.characterization.test.ts --coverage` and verify every ViewState variant in src/ui/connections-view-state.ts is exercised. Report any variant missing a test with file:line of the missing branch."
+)
+```
+
+---
+
+## Phase C — Pure `ConnectionsResultCache` (TDD)
+
+### Task C.1: `get` / `set` exact-match semantics
+
+**Files:**
+- Create: `open-connections/src/domain/connections/result-cache.ts`
+- Test: `open-connections/test/connections-result-cache.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// test/connections-result-cache.test.ts
+import { describe, it, expect } from 'vitest';
+import { ConnectionsResultCache } from '../src/domain/connections/result-cache';
+
+describe('ConnectionsResultCache', () => {
+  it('returns null for a cold miss', () => {
+    const c = new ConnectionsResultCache();
+    expect(c.get('a.md', 'fp-1')).toBeNull();
+  });
+
+  it('returns stored results on exact (path, fingerprint) hit', () => {
+    const c = new ConnectionsResultCache();
+    const results = [{ key: 'b1', score: 0.9 }] as any;
+    c.set('a.md', 'fp-1', results);
+    expect(c.get('a.md', 'fp-1')).toEqual(results);
+  });
+
+  it('treats fingerprint mismatch as a miss', () => {
+    const c = new ConnectionsResultCache();
+    c.set('a.md', 'fp-1', [{ key: 'b1' }] as any);
+    expect(c.get('a.md', 'fp-2')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `pnpm vitest run test/connections-result-cache.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Minimal implementation**
+
+```ts
+// src/domain/connections/result-cache.ts
+import type { ConnectionResult } from '../../types/entities';
+
+export class ConnectionsResultCache {
+  private readonly store = new Map<string, { fingerprint: string; results: readonly ConnectionResult[] }>();
+  get(path: string, fingerprint: string): readonly ConnectionResult[] | null {
+    const entry = this.store.get(path);
+    return entry && entry.fingerprint === fingerprint ? entry.results : null;
+  }
+  set(path: string, fingerprint: string, results: readonly ConnectionResult[]): void {
+    this.store.set(path, { fingerprint, results });
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm vitest run test/connections-result-cache.test.ts && pnpm run typecheck && pnpm run lint`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/connections/result-cache.ts test/connections-result-cache.test.ts
+git commit -m "feat(domain): ConnectionsResultCache exact-match get/set"
+```
+
+### Task C.2: `invalidate(path)` and `invalidateAll()`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// (append to test/connections-result-cache.test.ts)
+it('invalidate(path) removes only that path', () => {
+  const c = new ConnectionsResultCache();
+  c.set('a.md', 'fp', [{}] as any); c.set('b.md', 'fp', [{}] as any);
+  c.invalidate('a.md');
+  expect(c.get('a.md', 'fp')).toBeNull();
+  expect(c.get('b.md', 'fp')).not.toBeNull();
+});
+
+it('invalidateAll() clears everything', () => {
+  const c = new ConnectionsResultCache();
+  c.set('a.md', 'fp', [{}] as any); c.set('b.md', 'fp', [{}] as any);
+  c.invalidateAll();
+  expect(c.get('a.md', 'fp')).toBeNull();
+  expect(c.get('b.md', 'fp')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify fail**; **Step 3: Add methods**; **Step 4: Run to verify pass**; **Step 5: Commit**
+
+```ts
+invalidate(path: string): void { this.store.delete(path); }
+invalidateAll(): void { this.store.clear(); }
+```
+
+```bash
+git commit -m "feat(domain): ConnectionsResultCache invalidate(path) + invalidateAll()"
+```
+
+### Task C.3: LRU bound (per OQ-5 default `max=64`)
+
+- [ ] **Step 1: Failing test**
+
+```ts
+it('evicts the least-recently-used entry when over max', () => {
+  const c = new ConnectionsResultCache(2); // tiny bound for test
+  c.set('a.md', 'fp', [{}] as any);
+  c.set('b.md', 'fp', [{}] as any);
+  c.get('a.md', 'fp'); // bumps a
+  c.set('c.md', 'fp', [{}] as any); // should evict b
+  expect(c.get('b.md', 'fp')).toBeNull();
+  expect(c.get('a.md', 'fp')).not.toBeNull();
+  expect(c.get('c.md', 'fp')).not.toBeNull();
+});
+```
+
+- [ ] **Step 2-4: Implement LRU semantics using Map insertion-order + re-insert on hit**; **Step 5: Commit**
+
+```bash
+git commit -m "feat(domain): ConnectionsResultCache LRU bound (default 64)"
+```
+
+---
+
+## Phase D — Pure `decideRender` + SWR Orchestration (TDD)
+
+### Task D.1: `decideRender` pure decision function
+
+**Files:**
+- Create: `open-connections/src/domain/connections/render-orchestration.ts`
+- Test: `open-connections/test/connections-render-orchestration.test.ts`
+
+- [ ] **Step 1: Failing test (one case per decision branch)**
+
+```ts
+describe('decideRender', () => {
+  it('compute_fresh on cold cache, phase idle', () => { /* expect 'compute_fresh' */ });
+  it('serve_cached on hit, same fingerprint, phase idle', () => { /* expect 'serve_cached' */ });
+  it('revalidate_in_background on hit, same fingerprint, phase running', () => { /* expect 'revalidate_in_background' with staleResults */ });
+  it('compute_fresh on fingerprint mismatch even when entry exists', () => { /* expect 'compute_fresh' */ });
+  it('compute_fresh on phase error', () => { /* still recompute so user sees a fresh attempt */ });
+});
+```
+
+- [ ] **Steps 2-4: Minimal implementation + green tests**
+- [ ] **Step 5: Commit** — `feat(domain): decideRender — serve-cached vs. compute vs. revalidate`
+
+### Task D.2: Wire cache + decideRender into `ConnectionsView.renderView`
+
+**Files:**
+- Modify: `open-connections/src/ui/ConnectionsView.ts:114-end` (`renderView`)
+- Modify: `open-connections/src/ui/connections-view-results.ts` (support "apply cached results without container.empty()")
+- Test: `open-connections/test/connections-view-swr.integration.test.ts`
+
+- [ ] **Step 1: Failing integration test — same (path, fingerprint) re-entry skips container.empty()**
+
+```ts
+it('does not call container.empty() on identical re-render', async () => {
+  const { view, container } = mountWithCache(/* seeds cache: 'a.md'@fp-1 → [r1] */);
+  const emptySpy = vi.spyOn(container, 'empty');
+  await view.renderView('a.md'); // first render: fills from cache or compute
+  const before = emptySpy.mock.calls.length;
+  await view.renderView('a.md'); // re-entry: must not empty()
+  expect(emptySpy.mock.calls.length).toBe(before);
+});
+```
+
+- [ ] **Step 2: Failing integration test — fingerprint change invalidates and re-renders**
+
+```ts
+it('on fingerprint change invalidates cache and shows loading then new results', async () => { /* … */ });
+```
+
+- [ ] **Step 3: Failing integration test — running→idle transition revalidates exactly once**
+
+> Requires `Workspace.trigger()` seam — if the seam is missing, this test will silently no-op. Phase E adds it; this task either (a) waits on Phase E or (b) includes a local `trigger()` stub and migrates to the shared mock in Phase E.
+
+```ts
+it('revalidates on embed-state-changed: running→idle', async () => {
+  const { view, workspace, readerSetResults } = mountWithCache();
+  await view.renderView('a.md');
+  readerSetResults('a.md', [{ key: 'new' }]);
+  workspace.trigger('open-connections:embed-state-changed', { prev: 'running', phase: 'idle' });
+  await flushMicro();
+  expect(/* rendered results now include 'new' */).toBe(true);
+});
+```
+
+- [ ] **Steps 4-6: Minimal impl — renderView consults cache via decideRender; compute path fills cache; event handler invalidates path entry on running→idle**
+- [ ] **Step 7: Run full CI**
+- [ ] **Step 8: Commit** — `feat(ui): stale-while-revalidate Connections results pipeline`
+
+### Task D.3: Fingerprint source of truth — plumb through Reader
+
+- [ ] **Step 1: Failing test** — view uses `reader.getSearchModelFingerprint()` as the cache key; null fingerprint ⇒ always compute
+- [ ] **Steps 2-4: Impl**; **Step 5: Commit** — `feat(ui): use Reader fingerprint for SWR cache key`
+
+### Task D.4: Phase-D review gate
+
+- [ ] **Step 1: Dispatch `critic` subagent**
+
+```
+Agent(subagent_type="oh-my-claudecode:critic",
+  description="Phase D SWR correctness review",
+  prompt="Read render-orchestration.ts, ConnectionsView.renderView, and the SWR integration tests. Adversarially check: (1) does container.empty() truly skip on hit? (2) is revalidation idempotent under rapid-fire events? (3) does fingerprint=null correctly force compute_fresh? (4) any race between two concurrent renderView calls (check _renderGen interaction)? Report concrete counter-examples or sign off."
+)
+```
+
+- [ ] **Step 2: Resolve findings; tag `slice-1-phase-d-done` locally.**
+
+---
+
+## Phase E — Test Infrastructure Seam (shared Workspace.trigger mock)
+
+### Task E.1: Add `trigger(name, payload)` to `test/mocks/obsidian.ts`
+
+**Files:**
+- Modify: `open-connections/test/mocks/obsidian.ts`
+- Test: `open-connections/test/mocks/obsidian.trigger.test.ts` (new)
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { Workspace } from './obsidian';
+
+describe('Workspace mock trigger', () => {
+  it('invokes handlers registered via on()', () => {
+    const w = new Workspace(); const h = vi.fn();
+    w.on('file-open', h);
+    w.trigger('file-open', { path: 'a.md' });
+    expect(h).toHaveBeenCalledWith({ path: 'a.md' });
+  });
+
+  it('returns the registered event ref for unregistration', () => {
+    const w = new Workspace(); const h = vi.fn();
+    const ref = w.on('x', h); w.offref(ref);
+    w.trigger('x'); expect(h).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**; **Step 3: Extend mock to maintain a `Map<string, Set<Handler>>` and implement `trigger` / `offref`**; **Step 4: Run all existing tests to ensure no regressions**; **Step 5: Commit**
+
+```bash
+git commit -m "test(mocks): add Workspace.trigger/offref to obsidian mock"
+```
+
+### Task E.2: Migrate Phase-D SWR tests to use shared trigger mock
+
+- [ ] **Step 1: Replace any local trigger stub with import from `./mocks/obsidian`**; **Step 2: Full CI**; **Step 3: Commit** — `test: migrate SWR tests to shared trigger mock`
+
+### Task E.3: Final review + verifier
+
+- [ ] **Step 1: `code-reviewer` subagent over the full diff from Phase A start**
+- [ ] **Step 2: `verifier` subagent runs `pnpm run ci`, confirms coverage floor, and inspects each Success Criterion in the spec**
+- [ ] **Step 3: On sign-off, tag `slice-1-done` locally**
+
+---
+
+## Self-Review Checklist (run by the planner before handoff)
+
+- [ ] Every spec Success Criterion maps to at least one task above.
+- [ ] No placeholder strings (no "TBD", no "implement error handling").
+- [ ] File paths exist or are explicitly `Create` with rationale.
+- [ ] Commit messages follow the repo's conventional style (seen in `git log`).
+- [ ] Each task is ≤ 5 files touched.
+- [ ] TDD cadence: test first, verify fail, minimal impl, verify pass, commit — every task.
+- [ ] Any broadened cleanup is justified in the task notes as freeze-causal or test-enabling.
+- [ ] Any deferred spec item is explicitly documented with the behavior-risk / non-causal evidence that justified deferral.
+- [ ] No end-state production path still passes `view.plugin.block_collection` into render-time reads or result fetching.
+- [ ] ESLint layer walls are not violated (no `obsidian` in `src/types/` or `src/domain/`).
+- [ ] Writes (`import_source_blocks`, `data_adapter.save`, `autoQueueBlockEmbedding`) are untouched in Slice 1.
+
+---
+
+## Execution Handoff
+
+**Plan complete.** Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, two-stage review between tasks. Invoke via `superpowers:subagent-driven-development`.
+2. **Inline Execution** — Execute tasks in this session with checkpoints. Invoke via `superpowers:executing-plans`.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-20-reader-mutator-problem-definition.md
+++ b/docs/superpowers/specs/2026-04-20-reader-mutator-problem-definition.md
@@ -1,0 +1,231 @@
+# Reader-Mutator 분리 — 문제 정의 문서
+
+> **작성일**: 2026-04-20
+> **범위**: 문제 정의 전용. 해결 아키텍처는 별도 설계 문서에서 다룬다.
+> **프로젝트**: open-connections (Obsidian 플러그인, TypeScript)
+
+---
+
+## 1. 문서 목적 및 범위
+
+이 문서는 open-connections 플러그인의 현재 아키텍처적 문제를 정의하는 것만을 목적으로 한다. 오늘 브레인스토밍 세션에서 도출된 원칙, 증상, 근본 원인, 그리고 자기 철학 문서와의 괴리를 기록한다.
+
+**이 문서가 다루지 않는 것**: 구체적인 구현 전략, 클래스 설계, 파일 배치 결정. 그런 내용은 후속 설계 문서(Reader-Mutator Split Design)에서 다룬다.
+
+**배경**: 저자는 15,000개 이상의 노트를 보유한 볼트에서 이 플러그인을 사용한다. 임베딩 기반 의미론적 검색(Transformers.js)은 규모가 커질수록 현재 아키텍처의 결함이 UX 문제로 직결된다.
+
+---
+
+## 2. 브레인스토밍 여정 요약
+
+오늘 세션은 다음 열 단계를 거쳐 문제의 핵심에 도달했다.
+
+1. **초기 진단**: 파일 전환 시 네비게이션 랙(주 증상)과 콜드 스타트 시 빈 화면(부 증상) 확인.
+2. **첫 번째 재프레이밍**: "프로파일링이 잘 안 되는 게 문제가 아니라, 경로 자체가 너무 복잡한 게 문제." 측정 불가능함은 결과이지 원인이 아니다.
+3. **제약 명시**: 15K+ 노트 사용자도 느리지 않게. 기능을 붙일 때마다 누적된 "좋을 것 같아서 붙인 것들"이 UX를 갉아먹고 있다.
+4. **멘탈 모델 확립**: I(Input trigger) → P(Process embed) → O(Output view). 현재 코드는 이 경계를 지키지 않는다.
+5. **13초 디바운스 재검토**: 시간 기반 재계산은 불필요하다. 재계산은 파일을 열 때 그 순간 수행되어야 한다.
+6. **핵심 돌파구**: "Read와 Write를 구분하지 않은 것이 문제." 이것이 오늘 세션의 중심 테제다.
+7. **iframe 오해 수정**: iframe/Worker는 스케줄링 문제를 해결하는 수단이 아니라 CPU 오프로드 수단이다. 오늘의 문제는 스케줄링이 아니라 책임 분리다.
+8. **패턴 탐색**: CQRS, Repository, Event-sourced Mutator를 검토하고, Repository + Reactive Store를 최소 실현 방안으로 선택했다.
+9. **Writer 배치 후보 탐색**: domain/ 신규 클래스, EmbeddingKernelJobQueue 승격, ui/ 파사드. 아직 미결.
+10. **메타 돌파구**: 사용자가 직관적으로 표현한 한국어 문장들이 오래된 소프트웨어 원칙과 정확히 대응됨을 확인. 이것이 오늘 세션의 수확이다.
+
+---
+
+## 3. 대원칙 (Grand Principles)
+
+브레인스토밍 과정에서 사용자가 직접 표현한 문장들은 다음의 소프트웨어 원칙과 대응된다.
+
+| 사용자의 표현 | 원칙 | 출처 |
+|---|---|---|
+| "읽기와 쓰기를 분리하라" | Command-Query Separation (CQS) | Bertrand Meyer, 1988 — *Object-Oriented Software Construction* |
+| "공통의 타입으로 대화를 주고받아야" | Dependency Inversion Principle (DIP) | Robert C. Martin — SOLID의 D |
+| "API가 명시적으로 묶여야" | Design by Contract | Meyer — Eiffel 언어 설계 원칙 |
+| "한 곳만 읽게 만들자" | Single Source of Truth + Information Hiding | David Parnas, 1972 — "On the Criteria To Be Used in Decomposing Systems into Modules" |
+| "fan-out이 쉽도록 구조적으로" | Open/Closed Principle + Interface Segregation | SOLID의 O, I |
+
+**메타 원칙**: 모듈은 구현이 아니라 계약(타입)을 통해 대화한다.
+
+**Meyer의 CQS 한 줄 요약**: *"Asking a question should not change the answer."*
+
+이 다섯 원칙은 독립적으로 존재하지 않는다. CQS 위반은 DIP 위반을 유발하고, DIP 위반은 계약을 불분명하게 만들며, 불분명한 계약은 단일 진실 공급원을 파괴한다. 현재 코드베이스에서 이 연쇄가 실제로 관찰된다.
+
+---
+
+## 4. 현재 증상
+
+### 4.1 파일 전환 랙
+
+파일을 전환할 때 ConnectionsView가 눈에 띄게 지연된다. 사용자가 다른 노트로 이동하는 행위 자체가 무거운 연산을 동기적으로 촉발하기 때문이다. 15K+ 노트 볼트에서 이 랙은 명확하게 체감된다.
+
+### 4.2 콜드 스타트 빈 화면
+
+플러그인을 처음 로드하거나 새 파일을 열 때 ConnectionsView가 빈 상태로 나타났다가 데이터가 채워지는 흐름이 발생한다. 이전 결과를 재사용(stale-while-revalidate)하는 대신, 매번 초기화 후 재진입하는 구조이기 때문이다.
+
+이 두 증상은 서로 다른 버그가 아니다. 동일한 근본 원인의 두 가지 표현이다.
+
+---
+
+## 5. 근본 원인: 원칙별 위반 증거
+
+### 5.1 CQS 위반 — 읽기 작업이 상태를 변경한다
+
+**`src/ui/connections-view-state.ts:34-39`**
+
+`deriveConnectionsViewState()`는 이름부터 Query다. 호출자는 현재 상태를 읽어오는 것으로 기대한다. 그러나 내부에서 `import_source_blocks()`와 `data_adapter.save()`를 실행한다. 즉, 상태를 읽는 함수 안에서 Command가 실행된다. Meyer의 경고 그대로다: "답을 묻는 행위가 답을 바꿔버린다."
+
+**`src/domain/semantic-search.ts:88`**
+
+평균 벡터를 계산하는 코드 직후에 `evictVec(id)`를 호출한다. 벡터를 읽으러 갔더니 벡터가 사라지는 구조다. 읽기와 쓰기(상태 변경)가 한 흐름 안에 묶여 있어, 같은 입력으로 두 번 호출했을 때 결과가 달라진다.
+
+### 5.2 DIP 위반 — 고수준 모듈이 구체 구현에 직접 의존한다
+
+**`ConnectionsView` → `block_collection.for_source()` 직접 호출**
+
+`ConnectionsView`는 고수준 UI 컴포넌트다. `BlockReader` 같은 추상화 없이 `block_collection`의 구체 구현을 직접 호출한다. 이로 인해 테스트에서 목킹이 불가능하고, `block_collection` 구현을 교체할 때 뷰 코드도 함께 수정해야 한다.
+
+**`src/main.ts:92-117`**
+
+`SmartConnectionsPlugin` 클래스가 God Object로 자라났다. `block_collection`, `source_collection`, `embedding_job_queue`, `pendingReImportPaths`, `_embed_state`, `_embed_profiling`, `embed_adapter`, `_search_embed_model` 등 15개 이상의 내부 상태가 public 필드로 노출되어 있다. 어떤 collaborator든 이 필드를 직접 건드릴 수 있으며, 실제로 여러 곳에서 그렇게 하고 있다. 의존 방향이 역전되어 있지 않고, 모든 것이 중심 오브젝트에 결합되어 있다.
+
+### 5.3 Design by Contract 위반 — 계약이 명시되어 있지 않다
+
+**`for_source()`의 빈 배열 반환 조건 미명시**
+
+`for_source()`가 언제 빈 배열을 반환하는지에 대한 명시적 계약이 없다. 인덱스가 아직 안 만들어진 경우인가, 파일이 존재하지 않는 경우인가, 아니면 임베딩이 진행 중인 경우인가. 모든 호출자가 이 empty-case를 각자 다르게 추측하며 방어 코드를 작성한다.
+
+**Dirty 상태가 4곳에 흩어져 있다**
+
+"이 파일은 재임베딩이 필요하다"는 사실을 나타내는 상태가 네 곳에 분산되어 있다.
+
+- `pendingReImportPaths` — `main.ts:112`
+- Block 엔티티의 `queue_embed` 플래그
+- `EmbeddingKernelJobQueue` 내부 큐
+- `file-watcher.ts`의 13초 `setTimeout` 타이머
+
+어느 것이 권위 있는 진실인지 알 수 없다. 네 곳이 모두 조금씩 다른 dirty 개념을 추적하고 있으며, 통일된 계약이 없다.
+
+### 5.4 Information Hiding 위반 — 내부 구현이 외부에 노출된다
+
+**Plugin 필드가 public으로 노출**
+
+`SmartConnectionsPlugin`의 내부 상태가 public 필드로 선언되어 있어 어떤 외부 코드든 직접 읽고 쓸 수 있다. 캡슐화가 없는 상태다.
+
+**`src/ui/ConnectionsView.ts:66-94`**
+
+`ConnectionsView`(Read-side 소비자)가 8개의 workspace 이벤트를 직접 구독한다: `file-open`, `active-leaf-change`, `embed-state-changed`, `embed-progress` 등. Write-side에서 발생하는 이벤트들이 Read-side 뷰 컴포넌트로 직접 누수된다. 읽기 컴포넌트가 쓰기 사이드의 내부 진행 상황을 알아야 하는 구조는 정보 은닉의 반대다.
+
+### 5.5 OCP/ISP 위반 — 변경이 넓게 전파된다
+
+**`BlockCollection` 교체 비용**
+
+`BlockCollection`을 다른 구현으로 교체하려면 약 27개의 호출 지점을 수정해야 한다(추정). 좁은 인터페이스가 존재하지 않기 때문에 변경의 fan-out이 코드베이스 전체로 퍼진다. 이것은 OCP(변경에 닫혀 있어야 한다)와 ISP(불필요한 메서드에 의존하지 않아야 한다) 모두를 위반하는 결과다.
+
+---
+
+## 6. 왜 지금까지 못 고쳤나 — Pessimism Budget 누적
+
+각각의 "빨간 화살표"는 개별적으로는 합리적인 결정이었다. 문제는 합산이다.
+
+| 코드 패턴 | 원래 의도 |
+|---|---|
+| `evictVec()` | 메모리 위생 — 벡터 캐시 무한 증가 방지 |
+| `setTimeout(0)` yield (`flat-vector-index.ts`) | 협력적 스케줄링 — 메인 스레드 블로킹 방지 |
+| `container.empty()` | 방어적 DOM 리셋 — 이전 렌더 잔여물 제거 |
+| 13초 debounce | Burst 방지 — 잦은 저장 시 임베딩 폭발 억제 |
+| inline `import_source_blocks` | Lazy import — 불필요한 선행 로딩 회피 |
+| `autoQueueBlockEmbedding` | Self-healing — 인덱스 불일치 자동 복구 |
+
+각 레이어가 독립적으로 비관(pessimism) 예산을 소비했다. "이 경우엔 문제가 생길 수 있으니 방어 코드를 추가하자"는 판단이 여섯 번 쌓이면서, 합산 결과가 UX 하락으로 나타났다. 특히 blank-then-refill 패턴은 이 방어들이 겹쳐진 결과다: `container.empty()`로 지우고, lazy import를 기다리고, setTimeout yield로 스케줄을 넘기고, 다시 채우는 과정이 사용자 눈에는 빈 화면으로 보인다.
+
+---
+
+## 7. 자기 철학 문서와의 괴리
+
+`docs/embedding-pipeline-philosophy.md`는 현재 코드가 지향해야 할 방향을 이미 명시했다. 그러나 현재 구현은 그 철학을 세 가지 규칙에서 위반한다.
+
+### Rule 5 위반 — Stale-While-Revalidate 미구현
+
+**철학 문서의 명시**: "Connections View should focus on results and, at most, a lightweight qualitative notice such as 'index updating' or 'results may be stale'."
+
+**현재 구현**: blank-then-refill. 재계산이 필요할 때 뷰를 완전히 비웠다가 다시 채운다. 철학 문서가 명시적으로 기술한 stale-while-revalidate 패턴이 구현되어 있지 않다.
+
+### Rule 4 위반 — 진행 상황 표면이 3곳으로 분산
+
+**철학 문서의 명시**: "One authoritative progress surface."
+
+**현재 구현**: 진행 상황을 표시하는 UI 표면이 세 곳에 존재한다. Settings 화면, Status bar, ConnectionsView 배너. 어느 것이 권위 있는 표면인지 사용자도 개발자도 알 수 없다.
+
+### Rule 8 위반 — 관찰 가능성 미구현
+
+**철학 문서의 명시**: 큐 깊이, 경과 시간, 저장 케이던스, UI 교체 횟수를 관찰해야 한다.
+
+**현재 구현**: 이 지표들 중 어느 것도 측정되지 않는다. 철학 문서가 "측정해야 할 것"으로 명시한 항목이 구현 안 됨 상태다.
+
+이 세 가지 괴리는 철학 문서가 나쁘게 작성된 것이 아님을 의미한다. 방향은 이미 맞게 설정되어 있었다. 구현이 철학을 따라가지 못한 것이다.
+
+---
+
+## 8. 오늘 합의된 것 / 미결 사항
+
+### 합의된 것
+
+**멘탈 모델**: Read/Write 분리가 대원칙이다. ConnectionsView는 읽기만, Mutator는 쓰기만 담당한다.
+
+**가장 작은 오늘의 slice**: stale-while-revalidate. ConnectionsView에서 blank 화면을 없애는 것이 첫 번째 체감 가능한 개선이다.
+
+**설계 패턴**: Repository + Reactive Store. CQS + DIP + Information Hiding의 최소 구현으로, 과도한 CQRS 인프라 없이 원칙을 실현하는 방안이다.
+
+**4-slice 로드맵**:
+1. Stale-while-revalidate — ConnectionsView blank 제거
+2. Reader-Mutator interface 분리 — CQS + DIP 원칙 구조화
+3. DirtyRegistry + demand-driven — 13초 debounce 제거, 단일 dirty 진실 공급원
+4. Optional Web Worker — CPU 오프로드 (스케줄링이 아닌 연산 부담 감소)
+
+### 미결 사항
+
+**Writer 배치**: Mutator(Writer)를 어디에 둘 것인가. 세 가지 후보가 있다.
+- `domain/` 디렉터리에 신규 클래스로 추가
+- 기존 `EmbeddingKernelJobQueue`를 승격하여 Writer 역할 부여
+- `ui/` 파사드로 배치
+
+각 후보의 트레이드오프는 설계 문서에서 다룬다.
+
+**Updating-indicator UX 강도**: 재계산 중임을 사용자에게 얼마나 강하게 알릴 것인가. 세 가지 옵션이 있다.
+- 무표시 (완전한 stale-while-revalidate, 사용자는 결과만 본다)
+- 얇은 상단 로딩 바
+- 개별 결과 카드를 dim 처리
+
+**ViewState 타입의 `types/` 이동 범위**: 현재 ViewState 관련 타입이 어디까지 `types/` 디렉터리로 이동해야 하는지.
+
+---
+
+## 9. 다음 단계
+
+이 문서는 문제 정의에서 멈춘다. 다음 단계는 별도의 설계 문서를 작성하는 것이다.
+
+**후속 문서**: `2026-04-20-reader-mutator-split-design.md`
+
+설계 문서에서 다룰 내용: Reader interface 정의, Mutator(Writer) 배치 결정, DirtyRegistry 설계, Reactive Store 선택, 4-slice 구현 순서의 구체화.
+
+---
+
+## 10. 문서 자기 검토
+
+이 문서는 **문제 정의 전용**이다.
+
+포함된 것:
+- 오늘 브레인스토밍에서 도출된 원칙과 그 출처
+- 현재 코드에서 원칙이 위반된 증거 (file:line)
+- 위반이 발생하게 된 역사적 맥락 (pessimism budget)
+- 철학 문서와의 괴리
+- 합의된 방향과 미결 사항
+
+포함되지 않은 것:
+- 구체적인 클래스 설계나 인터페이스 정의
+- 파일 배치 결정
+- 구현 코드 스니펫
+- 단계별 구현 지시사항
+
+해결 아키텍처는 이 문서를 기반으로 작성될 별도의 설계 문서에서 다룬다.

--- a/docs/superpowers/specs/2026-04-20-slice-1-dip-seam-then-swr-spec.md
+++ b/docs/superpowers/specs/2026-04-20-slice-1-dip-seam-then-swr-spec.md
@@ -1,0 +1,196 @@
+# Spec: Slice 1 — DIP Seam, then SWR Results Cache
+
+> Derived from `2026-04-20-reader-mutator-problem-definition.md` §8 (4-slice roadmap).
+> Slice 1 only. Writer placement, broader `types/` split, and deep ISP decomposition are **deferred to Slice 2+**.
+
+## Objective
+
+Break the tight coupling between `ConnectionsView` and `SmartConnectionsPlugin`'s public fields so the view can be unit-tested, and land the Philosophy §5 "Stale-While-Revalidate" posture for the Connections panel.
+
+**Why this slice is first.** Feathers, *Working Effectively with Legacy Code*: "to get a test around code, you must break its dependencies". Today `ConnectionsView` transitively pulls `obsidian` through `view.plugin.block_collection.for_source(...)`, so any characterization test of the render pipeline needs either (a) a full `SmartConnectionsPlugin` stand-in or (b) deep per-test mocks of the whole plugin graph. Both are brittle. Introducing a narrow `ConnectionsReader` port (DIP) unlocks cheap stubs, which unlocks TDD for the SWR cache.
+
+**Concrete user-visible outcome.** When the user flips between two already-embedded notes, the Connections panel must not flash "loading → results". The result set must be served from cache for the currently-indexed (path, fingerprint) key and revalidate silently in the background when the embedding kernel reports `running → idle` (§5 of Philosophy: results-focused, SWR).
+
+**Execution rule (clarified 2026-04-20).** Treat the current Slice 1 spec as the default scope target, but if TDD evidence shows a spec item is not causally tied to the screen-transition freeze and fixing it now would raise behavior-risk, default to **freeze reduction + behavior preservation first** and defer that item explicitly. Adjacent cleanup is allowed only when it directly enables the tests or the freeze-focused refactor. Release metadata (`manifest.json`, versioning, release scripts) stays out of scope.
+
+## Tech Stack
+
+- TypeScript (strict), Node ≥ 18, pnpm workspaces
+- esbuild 0.21 bundler (CJS, ES2018)
+- Vitest 1.x + jsdom 24 for unit/integration tests
+- ESLint 9 flat config with `no-restricted-imports` layer walls
+- Obsidian plugin runtime (target desktop + mobile)
+
+## Commands
+
+```bash
+pnpm install                                # once
+pnpm run typecheck                          # tsc --noEmit
+pnpm run lint                               # ESLint src/ + worker/
+pnpm run test                               # Vitest single-run
+pnpm vitest run test/<file>.test.ts         # single file
+pnpm run ci                                 # build + lint + test (gate before commit/push)
+pnpm run dev                                # vault-selecting dev loop (only if manual QA needed)
+```
+
+All verification steps in the plan call `pnpm run typecheck` + the relevant `pnpm vitest run` file. `pnpm run ci` gates each commit on green.
+
+## Project Structure (Slice 1 deltas only)
+
+```
+src/
+├── types/
+│   └── connections-reader.ts         # NEW — port (DIP). Pure TS, NO obsidian import.
+├── domain/
+│   └── connections/
+│       ├── result-cache.ts           # NEW — pure (path, fingerprint) → ConnectionResult[] cache
+│       └── render-orchestration.ts   # NEW — pure decision: serve-from-cache vs. revalidate
+├── ui/
+│   ├── ConnectionsView.ts            # MODIFY — constructor takes reader; events call orchestration
+│   ├── connections-view-state.ts     # MODIFY — accept reader instead of view.plugin.* reads
+│   └── connections-reader-adapter.ts # NEW — wraps plugin into ConnectionsReader (composition root)
+└── main.ts                           # MODIFY — pass adapter to registerView factory
+
+test/
+├── mocks/
+│   └── obsidian.ts                   # MODIFY — add Workspace.trigger() (Phase E)
+├── connections-reader-adapter.test.ts          # NEW
+├── connections-result-cache.test.ts            # NEW
+├── connections-render-orchestration.test.ts    # NEW
+├── connections-view-state.characterization.test.ts  # NEW
+└── connections-view-swr.integration.test.ts    # NEW (Phase D capstone)
+```
+
+All new source files ≤ 200 LOC (docs/rules.md R4). `src/types/connections-reader.ts` MUST NOT import `obsidian` (ESLint-enforced).
+
+## Code Style
+
+Reader port (DIP, with one explicit test-enabling brownfield seam for on-demand block hydration):
+
+```ts
+// src/types/connections-reader.ts
+import type { ConnectionResult } from './entities';
+import type { EmbeddingBlockLike, EmbeddingSourceLike } from './obsidian-shims';
+import type { ParsedEmbedRuntimeState, EmbedStatePhase } from './embed-runtime';
+
+export interface ConnectionsReader {
+  isReady(): boolean;
+  isEmbedReady(): boolean;
+  getStatusState(): 'ok' | 'error' | string;
+  hasPendingReImport(path: string): boolean;
+  getBlocksForSource(path: string): EmbeddingBlockLike[];
+  getSource(path: string): EmbeddingSourceLike | null;
+  ensureBlocksForSource(path: string): Promise<readonly EmbeddingBlockLike[]>;
+  getConnectionsForSource(path: string, limit?: number): Promise<readonly ConnectionResult[]>;
+  getEmbedRuntimeState(): ParsedEmbedRuntimeState | null;
+  getSearchModelFingerprint(): string | null;
+  getKernelPhase(): EmbedStatePhase;      // 'idle' | 'running' | 'error' — SWR driver
+  isDiscovering(): boolean;               // covers ConnectionsView.ts:117 `_discovering` read
+}
+```
+
+Pure cache (one responsibility):
+
+```ts
+// src/domain/connections/result-cache.ts
+export class ConnectionsResultCache {
+  private readonly store = new Map<string, { fingerprint: string; results: readonly ConnectionResult[] }>();
+  get(path: string, fingerprint: string): readonly ConnectionResult[] | null { /* exact (path, fp) match only */ }
+  set(path: string, fingerprint: string, results: readonly ConnectionResult[]): void { /* ... */ }
+  invalidate(path: string): void { /* ... */ }
+  invalidateAll(): void { /* ... */ }
+}
+```
+
+Render orchestration — pure decision (no DOM, no async):
+
+```ts
+// src/domain/connections/render-orchestration.ts
+export type RenderDecision =
+  | { kind: 'serve_cached'; results: readonly ConnectionResult[] }
+  | { kind: 'compute_fresh' }
+  | { kind: 'revalidate_in_background'; staleResults: readonly ConnectionResult[] };
+
+export function decideRender(
+  input: { path: string; fingerprint: string; kernelPhase: 'idle' | 'running' | 'error' },
+  cache: ConnectionsResultCache,
+): RenderDecision { /* explicit match on (cache-hit? × fingerprint-change? × phase) */ }
+```
+
+Conventions:
+- Types in `src/types/**` are the contract; no behavior there.
+- Domain modules are pure; no `obsidian`, no `window`, no `setTimeout`.
+- UI modules do the I/O: DOM writes, workspace events, timers.
+- Each function/class gets one test file with multiple `describe` blocks per behavior.
+
+## Testing Strategy
+
+**Levels.** From bottom up:
+
+| Level | Scope | Isolation mechanism | Target |
+|-------|-------|---------------------|--------|
+| L0 — unit (pure) | `result-cache.ts`, `render-orchestration.ts` | none needed; pure TS | 100 % branch |
+| L1 — unit (adapter) | `connections-reader-adapter.ts` | fake plugin object (plain literal) | 100 % method |
+| L2 — unit (state) | `connections-view-state.ts::deriveConnectionsViewState` | fake `ConnectionsReader` | each `ViewState` variant ≥ 1 test |
+| L3 — integration | `ConnectionsView.renderView` characterization | `ConnectionsView` + jsdom + fake reader + Workspace mock | each event-driven path |
+| L4 — SWR capstone | Full view + cache + orchestrator | fake reader + `Workspace.trigger()` seam | §5 SWR invariants |
+
+**Characterization first.** Phase B captures *today's* behavior before any cache is added. This guards against accidental regressions when Phase C/D replace render logic.
+
+**Mock-usage rules (steel-manning from Phase E plan):**
+- `test/mocks/obsidian.ts` gets a real `trigger(name, payload?)` that walks `on()` handlers. Without this, revalidation tests would either couple to private method calls or pass falsely when no handler is present.
+- `ConnectionsReader` in every view test is a plain object literal, not a `vi.mock('../main')`. This keeps tests readable and refactor-resilient.
+
+**Coverage floor.** Slice 1 must not lower repo coverage. Current thresholds (vitest.config.ts): statements 60 %, branches 68 %, functions 50 %. The new pure modules should exceed 95 %.
+
+## Boundaries
+
+**Always do**
+- Follow docs/rules.md R1–R6. Every new file justifies its existence and stays ≤ 200 LOC.
+- Respect the ESLint layer walls: `src/domain/**`, `src/types/**`, `src/utils/**` may not import `obsidian`.
+- Run `pnpm run ci` before every commit listed in the plan.
+- Keep each commit atomic around one bite-sized task (writing-plans discipline).
+- Use characterization/TDD evidence to justify any broadened cleanup beyond the narrow seam/cache path.
+- Use superpowers subagent-driven-development for execution; dispatch `code-reviewer` + `verifier` between phase boundaries.
+
+**Ask first**
+- Any Slice-2 scope leak (writer placement, broader Reader surface, moving types across layers).
+- Bumping vitest coverage thresholds.
+- Touching `manifest.json` version, release scripts, or GitHub Actions.
+- Cutting a new branch from `issue-74-ataraxia-state-latency` vs. continuing on it (the tree is currently dirty on that branch).
+
+**Never do**
+- Introduce `obsidian` import into `src/types/**` or `src/domain/**`.
+- Remove or weaken `no-restricted-imports` ESLint rules.
+- Replace the existing `updateConnectionsProgressBanner` test pattern (it is the blueprint; don't rewrite it).
+- Skip characterization tests (Phase B) and go directly to Phase C — we'd lose the regression net.
+- Force through a Slice 1 item that lacks a freeze/testability justification when the evidence says it raises behavior risk.
+- Bundle write-side changes (`import_source_blocks`, `data_adapter.save`, `autoQueueBlockEmbedding`) into Slice 1.
+
+## Success Criteria
+
+Slice 1 is done when *all* of the following are objectively true:
+
+1. `src/types/connections-reader.ts` exists, exports `ConnectionsReader`, and is imported by both `ConnectionsView.ts` and `connections-view-state.ts`. No production file passes `view.plugin.block_collection` into the render path.
+2. `connections-reader-adapter.ts` is instantiated exactly once in `main.ts` and passed to `ConnectionsView`'s constructor. ESLint + tsc pass.
+3. `ConnectionsResultCache` and `decideRender` are pure (no Obsidian, no globals) and covered by ≥ 95 % branches.
+4. Re-opening the same note twice with no fingerprint change calls `container.empty()` **zero times** after the first render (verified via L4 integration test with jsdom + spy).
+5. A `running → idle` transition on `open-connections:embed-state-changed` invalidates the path's cache entry and triggers exactly one re-render (L4 integration test).
+6. A fingerprint change (e.g. model switch) invalidates all cache entries and shows a loading banner before the next results arrive.
+7. `pnpm run ci` is green. Coverage does not drop below current thresholds.
+8. `test/mocks/obsidian.ts` has a working `Workspace.trigger()` that calls registered handlers.
+9. A `code-reviewer` subagent and a `verifier` subagent both sign off on the diff in separate passes (no same-context self-approval).
+
+## Open Questions
+
+| # | Question | Default assumption if unresolved |
+|---|----------|-----------------------------------|
+| OQ-1 | Should Slice 1 surface a subtle "revalidating…" indicator in the UI when the kernel is running but we serve from cache? | **No indicator.** Reuse existing progress banner for running-phase messaging; keep results pane stable. |
+| OQ-2 | Cut a new branch off `main` for Slice 1 or continue on `issue-74-ataraxia-state-latency`? | **Ask before cutting.** Commit or stash current dirty files first. |
+| OQ-3 | Where does the `EmbeddingBlockLike`/`EmbeddingSourceLike` shim live? New file in `types/` or extend `types/obsidian-shims.ts`? | Extend `types/obsidian-shims.ts` (fewer files, same owner). |
+| OQ-4 | Do we collapse the 10 call sites of `for_source(path)` to go through the Reader in Slice 1? | **No.** Only the ConnectionsView render path is rerouted; bulk migration is Slice 2. |
+| OQ-5 | What is the cache eviction policy? | LRU with `max=64` entries, clearable via `invalidateAll()`. (Revisit if profile shows GC pressure.) |
+
+---
+
+**Next artifact:** `docs/superpowers/plans/2026-04-20-slice-1-dip-seam-then-swr.md` (the TDD-granular plan) is derived from this spec. Update this spec first when anything changes; the plan follows.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "prepare": "husky",
     "profile:scaling": "node scripts/profile-scaling.mjs",
     "profile:freeze-flows": "node scripts/profile-freeze-flows.mjs",
-    "profile:live-vault": "node scripts/profile-live-vault.mjs"
+    "profile:live-vault": "node scripts/profile-live-vault.mjs",
+    "profile:state-latency": "node scripts/profile-state-latency.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/profile-state-latency-report.mjs
+++ b/scripts/profile-state-latency-report.mjs
@@ -1,0 +1,108 @@
+const INTERACTIVE_SETTLE_MS = 1_000;
+
+function round(value) {
+  return Number(value.toFixed(1));
+}
+
+export function percentile(values, p) {
+  if (!Array.isArray(values) || values.length === 0) return null;
+  const sorted = [...values].sort((left, right) => left - right);
+  if (sorted.length === 1) return sorted[0];
+  const index = (sorted.length - 1) * p;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return sorted[lower];
+  const weight = index - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
+export function classifyLatencyImpact(stateId, sampleMetrics) {
+  const hasTimeoutFailure = sampleMetrics.some((sample) => sample.timeoutCount > 0);
+  const hasEmptyPolls = sampleMetrics.some((sample) => sample.emptyPollCount > 0);
+
+  if (stateId === 'startup-core' || stateId === 'startup-embedding-init') {
+    if (hasTimeoutFailure) return 'interactive-blocker';
+    return hasEmptyPolls ? 'responsive-but-degraded' : 'background';
+  }
+
+  if (stateId === 'startup-background-import' || stateId === 'new-note-debounce-reimport' || stateId === 'active-leaf-debounce') {
+    if (hasTimeoutFailure) return 'interactive-blocker';
+    return 'background';
+  }
+
+  if (hasTimeoutFailure || hasEmptyPolls) return 'interactive-blocker';
+
+  const settledValues = sampleMetrics
+    .map((sample) => sample.viewSettledMs ?? sample.lookupSettledMs ?? sample.sourceImportedMs ?? sample.completedMs ?? sample.primaryDurationMs)
+    .filter((value) => Number.isFinite(value));
+
+  if (settledValues.length === 0) return 'responsive-but-degraded';
+
+  return settledValues.some((value) => value > INTERACTIVE_SETTLE_MS)
+    ? 'responsive-but-degraded'
+    : 'background';
+}
+
+export function buildExplanation(state, summary) {
+  const median = summary.medianMs ?? 'n/a';
+
+  switch (state.id) {
+    case 'startup-core':
+      return `Startup core init is a reload/startup-only cost (${median}ms median), not a note-switch blocker unless CLI responsiveness also drops.`;
+    case 'startup-embedding-init':
+      return `Embedding init is a startup-only warmup cost (${median}ms median); it matters for startup readiness more than interactive note switching.`;
+    case 'startup-background-import':
+      return `Background import continues after startup and took ${median}ms median here; it is background work unless polls show CLI/UI responsiveness loss.`;
+    case 'new-note-debounce-reimport':
+      return `This latency is mostly the fixed debounce/re-import wait before the new note is imported; current evidence should reveal whether it stays background-only or leaks into interaction.`;
+    case 'note-switch-indexed':
+      return `This is the best-case note-switch path, reported as an end-to-end proxy from note-switch trigger plus CLI/view settle; if it stays high, ordinary note switching itself is a UX problem.`;
+    case 'note-switch-unindexed':
+      return `This is the key suspect path, reported as an end-to-end proxy: switching to a note with no blocks yet can synchronously import, parse, and save blocks during render before the view settles.`;
+    case 'active-leaf-debounce':
+      return `This captures the active-leaf-change debounce window; if it stays responsive, it is queued background overhead rather than the direct UI blocker.`;
+    case 'lookup-open':
+      return `Lookup-open latency is reported as a trigger-plus-settle proxy for showing the search surface itself; it is separate from the first semantic query.`;
+    case 'lookup-first-query':
+      return `Lookup-first-query latency captures trigger-plus-settle search/render cost after the view opens; it should be separated from note-switch import costs.`;
+    default:
+      return state.description ?? `Measured ${state.label} latency.`;
+  }
+}
+
+export function summarizeLatencyState(state, sampleMetrics) {
+  const completedValues = sampleMetrics
+    .map((sample) => sample.primaryDurationMs)
+    .filter((value) => Number.isFinite(value));
+  const triggerValues = sampleMetrics
+    .map((sample) => sample.triggerDurationMs)
+    .filter((value) => Number.isFinite(value));
+
+  const medianMs = completedValues.length ? round(percentile(completedValues, 0.5)) : null;
+  const p95Ms = completedValues.length >= 3 ? round(percentile(completedValues, 0.95)) : null;
+  const worstCaseMs = completedValues.length ? round(Math.max(...completedValues)) : null;
+  const triggerMedianMs = triggerValues.length ? round(percentile(triggerValues, 0.5)) : null;
+  const triggerWorstCaseMs = triggerValues.length ? round(Math.max(...triggerValues)) : null;
+  const timeoutCount = sampleMetrics.reduce((sum, sample) => sum + (sample.timeoutCount ?? 0), 0);
+  const emptyPollCount = sampleMetrics.reduce((sum, sample) => sum + (sample.emptyPollCount ?? 0), 0);
+  const freezeDetected = sampleMetrics.some((sample) => sample.freezeDetected);
+  const impact = classifyLatencyImpact(state.id, sampleMetrics);
+
+  return {
+    id: state.id,
+    label: state.label,
+    codePath: state.codePath,
+    sampleCount: sampleMetrics.length,
+    medianMs,
+    p95Ms,
+    worstCaseMs,
+    triggerMedianMs,
+    triggerWorstCaseMs,
+    timeoutCount,
+    emptyPollCount,
+    freezeDetected,
+    impact,
+    explanation: buildExplanation(state, { medianMs, p95Ms, worstCaseMs, impact }),
+    samples: sampleMetrics,
+  };
+}

--- a/scripts/profile-state-latency.mjs
+++ b/scripts/profile-state-latency.mjs
@@ -1,0 +1,690 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+
+import { summarizeLatencyState } from './profile-state-latency-report.mjs';
+
+const DEFAULT_TIMEOUT_MS = 3_000;
+const DEFAULT_POLL_INTERVAL_MS = 500;
+const DEFAULT_POLL_TIMEOUT_MS = 20_000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 90_000;
+const DEFAULT_ARTIFACT_DIR = resolve(process.cwd(), 'artifacts/state-latency');
+
+const STATE_DEFS = {
+  startupCore: {
+    id: 'startup-core',
+    label: 'startup core init',
+    codePath: ['src/ui/plugin-initialization.ts:61-113'],
+  },
+  startupEmbedding: {
+    id: 'startup-embedding-init',
+    label: 'startup embedding init',
+    codePath: ['src/ui/plugin-initialization.ts:116-188'],
+  },
+  startupBackgroundImport: {
+    id: 'startup-background-import',
+    label: 'startup background import',
+    codePath: ['src/ui/plugin-initialization.ts:154-179', 'src/ui/collection-block-import.ts:22-83'],
+  },
+  newNote: {
+    id: 'new-note-debounce-reimport',
+    label: 'new-note debounce/re-import latency',
+    codePath: ['src/domain/config.ts:56-63', 'src/ui/file-watcher.ts:79-163'],
+  },
+  noteSwitchIndexed: {
+    id: 'note-switch-indexed',
+    label: 'note-switch to already-indexed note',
+    codePath: ['src/ui/ConnectionsView.ts:114-146', 'src/ui/connections-view-state.ts:21-49'],
+  },
+  noteSwitchUnindexed: {
+    id: 'note-switch-unindexed',
+    label: 'note-switch to note with no blocks yet',
+    codePath: [
+      'src/ui/ConnectionsView.ts:114-146',
+      'src/ui/connections-view-state.ts:29-38',
+      'src/domain/entities/BlockCollection.ts:85-117',
+      'src/domain/entities/markdown-splitter.ts:23-76',
+    ],
+  },
+  activeLeafDebounce: {
+    id: 'active-leaf-debounce',
+    label: 'active-leaf-change debounce latency',
+    codePath: ['src/ui/file-watcher.ts:62-66', 'src/ui/file-watcher.ts:91-101'],
+  },
+  lookupOpen: {
+    id: 'lookup-open',
+    label: 'lookup view open latency',
+    codePath: ['src/ui/LookupView.ts:53-115'],
+  },
+  lookupFirstQuery: {
+    id: 'lookup-first-query',
+    label: 'lookup first-query latency',
+    codePath: ['src/ui/LookupView.ts:119-154'],
+  },
+};
+
+function parseArgs(argv) {
+  const options = {
+    vault: 'Ataraxia',
+    query: 'productivity',
+    samples: 3,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+    pollTimeoutMs: DEFAULT_POLL_TIMEOUT_MS,
+    startupTimeoutMs: DEFAULT_STARTUP_TIMEOUT_MS,
+    artifactDir: DEFAULT_ARTIFACT_DIR,
+  };
+
+  for (const arg of argv) {
+    const [key, value] = arg.split('=');
+    if (key === '--vault' && value) options.vault = value;
+    if (key === '--query' && value) options.query = value;
+    if (key === '--samples' && value) options.samples = Number.parseInt(value, 10);
+    if (key === '--timeout-ms' && value) options.timeoutMs = Number.parseInt(value, 10);
+    if (key === '--poll-interval-ms' && value) options.pollIntervalMs = Number.parseInt(value, 10);
+    if (key === '--poll-timeout-ms' && value) options.pollTimeoutMs = Number.parseInt(value, 10);
+    if (key === '--startup-timeout-ms' && value) options.startupTimeoutMs = Number.parseInt(value, 10);
+    if (key === '--artifact-dir' && value) options.artifactDir = resolve(value);
+  }
+
+  return options;
+}
+
+function stamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function runObsidian(vault, args, timeoutMs) {
+  return new Promise((resolveRun) => {
+    const startedAt = Date.now();
+    const child = spawn('obsidian', [`vault=${vault}`, ...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+    child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+    child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      resolveRun({
+        code,
+        signal,
+        stdout,
+        stderr,
+        timedOut,
+        durationMs: Date.now() - startedAt,
+      });
+    });
+  });
+}
+
+function parseEval(stdout) {
+  const line = stdout
+    .split('\n')
+    .map((value) => value.trim())
+    .find((value) => value.startsWith('=> '));
+  if (!line) return null;
+  const payload = line.slice(3);
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return payload || null;
+  }
+}
+
+async function evalJson(vault, code, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const result = await runObsidian(vault, ['eval', `code=${code}`], timeoutMs);
+  const parsed = result.timedOut ? null : parseEval(result.stdout);
+  const emptyOutput = !result.timedOut
+    && (result.code ?? 0) === 0
+    && ((result.stdout ?? '').trim().length === 0 || parsed === null);
+
+  return {
+    ...result,
+    parsed,
+    emptyOutput,
+  };
+}
+
+function jsString(value) {
+  return JSON.stringify(value);
+}
+
+async function ensureConnectionsView(vault, timeoutMs) {
+  await runObsidian(vault, ['command', 'id=open-connections:connections-view'], timeoutMs);
+  await evalJson(
+    vault,
+    `(async()=>{const leaf=app.workspace.getLeavesOfType("open-connections-view")[0]; if(leaf){ await app.workspace.revealLeaf(leaf); } return JSON.stringify({revealed:!!leaf});})()`,
+    timeoutMs,
+  );
+  await sleep(300);
+}
+
+async function ensureLookupView(vault, timeoutMs) {
+  await runObsidian(vault, ['command', 'id=open-connections:open-lookup-view'], timeoutMs);
+  await sleep(300);
+}
+
+async function closeLeavesOfType(vault, type, timeoutMs) {
+  await evalJson(
+    vault,
+    `(async()=>{for (const leaf of app.workspace.getLeavesOfType(${jsString(type)})) { await leaf.detach(); } return JSON.stringify({closed:${jsString(type)}});})()`,
+    timeoutMs,
+  );
+}
+
+async function getCandidateNotes(vault, sampleCount, timeoutMs) {
+  const code = `(() => {
+    const plugin = app.plugins.plugins["open-connections"];
+    const sourceIndex = plugin?.block_collection?._sourceIndex;
+    const activeFile = app.workspace.getActiveFile()?.path ?? null;
+    const indexed = [];
+    for (const [sourceKey, blockKeys] of sourceIndex?.entries?.() ?? []) {
+      let embedded = false;
+      for (const blockKey of blockKeys ?? []) {
+        const block = plugin?.block_collection?.items?.[blockKey];
+        if (block?.has_embed?.()) {
+          embedded = true;
+          break;
+        }
+      }
+      if (!embedded) continue;
+      indexed.push(sourceKey);
+      if (indexed.length >= ${sampleCount * 3}) break;
+    }
+
+    return JSON.stringify({ activeFile, indexed });
+  })()`;
+
+  const result = await evalJson(vault, code, timeoutMs);
+  if (!result.parsed || typeof result.parsed !== 'object') {
+    throw new Error('Failed to discover candidate notes for latency profiling.');
+  }
+  return result.parsed;
+}
+
+async function pollScenario({ vault, timeoutMs, pollIntervalMs, pollCodeFactory, stopWhen }) {
+  const startedAt = Date.now();
+  const trace = [];
+  let emptyPollCount = 0;
+  let timeoutCount = 0;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const elapsedMs = Date.now() - startedAt;
+    const pollResult = await evalJson(vault, pollCodeFactory(), Math.min(DEFAULT_TIMEOUT_MS, pollIntervalMs + 1_000));
+    const entry = {
+      elapsedMs,
+      durationMs: pollResult.durationMs,
+      timedOut: pollResult.timedOut,
+      emptyOutput: pollResult.emptyOutput,
+      parsed: pollResult.parsed,
+    };
+    if (pollResult.timedOut) timeoutCount += 1;
+    if (pollResult.emptyOutput) emptyPollCount += 1;
+    trace.push(entry);
+
+    if (stopWhen(entry)) {
+      return { trace, timeoutCount, emptyPollCount, completed: true };
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  return { trace, timeoutCount, emptyPollCount, completed: false };
+}
+
+function firstMatchingElapsed(trace, predicate) {
+  const match = trace.find((entry) => !entry.timedOut && !entry.emptyOutput && predicate(entry.parsed));
+  return match ? match.elapsedMs : null;
+}
+
+async function captureStartupStages(vault, options) {
+  await runObsidian(vault, ['plugin:reload', 'id=open-connections'], options.timeoutMs);
+
+  const pollResult = await pollScenario({
+    vault,
+    timeoutMs: options.startupTimeoutMs,
+    pollIntervalMs: options.pollIntervalMs,
+    pollCodeFactory: () => `(() => {
+      const plugin = app.plugins.plugins["open-connections"];
+      const runtime = plugin?.getEmbedRuntimeState?.();
+      const profiling = runtime?.profiling ?? plugin?.getEmbedProfilingState?.() ?? null;
+      return JSON.stringify({
+        ready: !!plugin?.ready,
+        embedReady: !!plugin?.embed_ready,
+        phase: plugin?._embed_state?.phase ?? null,
+        activeStage: profiling?.activeStage ?? null,
+        recentStages: profiling?.recentStages ?? [],
+      });
+    })()`,
+    stopWhen: (entry) => {
+      const parsed = entry.parsed;
+      if (!parsed || typeof parsed !== 'object') return false;
+      const recent = Array.isArray(parsed.recentStages) ? parsed.recentStages : [];
+      return parsed.ready && recent.some((stage) => stage?.name === 'init:background-import') && !parsed.activeStage;
+    },
+  });
+
+  const lastParsed = [...pollResult.trace].reverse().find((entry) => entry.parsed && typeof entry.parsed === 'object')?.parsed ?? {};
+  const recentStages = Array.isArray(lastParsed.recentStages) ? lastParsed.recentStages : [];
+  const findStage = (name) => recentStages.find((stage) => stage?.name === name) ?? null;
+
+  return {
+    raw: pollResult,
+    states: [
+      {
+        ...STATE_DEFS.startupCore,
+        sampleCount: 1,
+        samples: [{
+          primaryDurationMs: findStage('init:core')?.durationMs ?? null,
+          timeoutCount: pollResult.timeoutCount,
+          emptyPollCount: pollResult.emptyPollCount,
+          freezeDetected: pollResult.timeoutCount > 0 || pollResult.emptyPollCount > 0,
+          trace: pollResult.trace,
+        }],
+      },
+      {
+        ...STATE_DEFS.startupEmbedding,
+        sampleCount: 1,
+        samples: [{
+          primaryDurationMs: findStage('init:embedding')?.durationMs ?? null,
+          timeoutCount: pollResult.timeoutCount,
+          emptyPollCount: pollResult.emptyPollCount,
+          freezeDetected: pollResult.timeoutCount > 0 || pollResult.emptyPollCount > 0,
+          trace: pollResult.trace,
+        }],
+      },
+      {
+        ...STATE_DEFS.startupBackgroundImport,
+        sampleCount: 1,
+        samples: [{
+          primaryDurationMs: findStage('init:background-import')?.durationMs ?? null,
+          timeoutCount: pollResult.timeoutCount,
+          emptyPollCount: pollResult.emptyPollCount,
+          freezeDetected: pollResult.timeoutCount > 0 || pollResult.emptyPollCount > 0,
+          trace: pollResult.trace,
+        }],
+      },
+    ],
+  };
+}
+
+async function sampleNewNote(vault, options, sampleIndex) {
+  const notePath = `oc-state-latency-note-${Date.now()}-${sampleIndex}.md`;
+  const noteContent = [
+    '# State latency sample',
+    '',
+    'This temporary note exists to measure debounce, source import, block import, and embedding latency.',
+    '',
+    'productivity obsidian semantic search embeddings background import connections view.',
+  ].join('\n');
+
+  const createCode = `(async()=>{const path=${jsString(notePath)}; const content=${jsString(noteContent)}; const existing=app.vault.getAbstractFileByPath(path); if(existing){await app.vault.delete(existing,true);} await app.vault.create(path, content); return JSON.stringify({path});})()`;
+  await evalJson(vault, createCode, options.timeoutMs);
+
+  const pollResult = await pollScenario({
+    vault,
+    timeoutMs: options.pollTimeoutMs,
+    pollIntervalMs: options.pollIntervalMs,
+    pollCodeFactory: () => `(() => {
+      const path = ${jsString(notePath)};
+      const plugin = app.plugins.plugins["open-connections"];
+      const source = plugin?.source_collection?.get?.(path) ?? null;
+      const blocks = plugin?.block_collection?.for_source?.(path) ?? [];
+      const embeddedBlockCount = blocks.filter((block) => block?.has_embed?.()).length;
+      return JSON.stringify({
+        path,
+        sourceExists: !!source,
+        blockCount: blocks.length,
+        embeddedBlockCount,
+        pendingReimport: plugin?.pendingReImportPaths?.has?.(path) ?? false,
+        reImportScheduled: !!plugin?.re_import_timeout,
+        phase: plugin?._embed_state?.phase ?? null,
+        activeStage: plugin?.getEmbedProfilingState?.()?.activeStage ?? null,
+        lastError: plugin?._embed_state?.lastError ?? null,
+      });
+    })()`,
+    stopWhen: (entry) => {
+      const parsed = entry.parsed;
+      return !!parsed && parsed.embeddedBlockCount > 0 && !parsed.pendingReimport;
+    },
+  });
+
+  const sourceImportedMs = firstMatchingElapsed(pollResult.trace, (parsed) => parsed?.sourceExists);
+  const blockImportedMs = firstMatchingElapsed(pollResult.trace, (parsed) => (parsed?.blockCount ?? 0) > 0);
+  const embeddedMs = firstMatchingElapsed(pollResult.trace, (parsed) => (parsed?.embeddedBlockCount ?? 0) > 0);
+  const pendingClearedMs = firstMatchingElapsed(pollResult.trace, (parsed) => parsed && parsed.pendingReimport === false && parsed.sourceExists);
+
+  const cleanupCode = `(async()=>{const path=${jsString(notePath)}; const file=app.vault.getAbstractFileByPath(path); if(file){await app.vault.delete(file,true);} return "deleted";})()`;
+  await evalJson(vault, cleanupCode, options.timeoutMs);
+
+  return {
+    primaryDurationMs: sourceImportedMs ?? embeddedMs ?? options.pollTimeoutMs,
+    completedMs: embeddedMs,
+    sourceImportedMs,
+    blockImportedMs,
+    pendingClearedMs,
+    timeoutCount: pollResult.timeoutCount,
+    emptyPollCount: pollResult.emptyPollCount,
+    freezeDetected: pollResult.timeoutCount > 0 || pollResult.emptyPollCount > 0,
+    trace: pollResult.trace,
+  };
+}
+
+async function sampleNoteSwitch(vault, options, targetPath) {
+  await ensureConnectionsView(vault, options.timeoutMs);
+  const switchCode = `(async()=>{const path=${jsString(targetPath)}; const file=app.vault.getAbstractFileByPath(path); if(!file){return JSON.stringify({error:"missing-file", path});} const leaf=app.workspace.getMostRecentLeaf?.() ?? app.workspace.getLeaf(false); await leaf.openFile(file); const connLeaf=app.workspace.getLeavesOfType("open-connections-view")[0]; if(connLeaf){ await app.workspace.revealLeaf(connLeaf); await connLeaf.view.renderView(path); } return JSON.stringify({path, rendered:!!connLeaf});})()`;
+  const trigger = await evalJson(vault, switchCode, options.timeoutMs);
+
+  const pollResult = await pollScenario({
+    vault,
+    timeoutMs: options.pollTimeoutMs,
+    pollIntervalMs: options.pollIntervalMs,
+    pollCodeFactory: () => `(() => {
+      const path = ${jsString(targetPath)};
+      const plugin = app.plugins.plugins["open-connections"];
+      const leaf = app.workspace.getLeavesOfType("open-connections-view")[0];
+      const view = leaf?.view;
+      const text = (view?.containerEl?.textContent ?? "").replace(/\\s+/g, " ").trim().slice(0, 400);
+      const loading = /Importing note|Embedding this note|Open Connections is loading|Loading/.test(text);
+      const resultsCount = view?.containerEl?.querySelectorAll?.("[role=listitem]")?.length ?? 0;
+      return JSON.stringify({
+        activeFile: app.workspace.getActiveFile()?.path ?? null,
+        targetPath: path,
+        lastRenderedPath: view?.lastRenderedPath ?? null,
+        loading,
+        text,
+        resultsCount,
+        phase: plugin?._embed_state?.phase ?? null,
+        activeStage: plugin?.getEmbedProfilingState?.()?.activeStage ?? null,
+        pendingReimport: plugin?.pendingReImportPaths?.has?.(path) ?? false,
+        reImportScheduled: !!plugin?.re_import_timeout,
+      });
+    })()`,
+    stopWhen: (entry) => {
+      const parsed = entry.parsed;
+      return !!parsed
+        && parsed.activeFile === targetPath
+        && parsed.lastRenderedPath === targetPath
+        && !parsed.loading;
+    },
+  });
+
+  const firstResponsiveMs = firstMatchingElapsed(pollResult.trace, () => true);
+  const viewSettledMs = firstMatchingElapsed(
+    pollResult.trace,
+    (parsed) => parsed?.activeFile === targetPath && parsed?.lastRenderedPath === targetPath && !parsed?.loading,
+  );
+  const backgroundDoneMs = firstMatchingElapsed(
+    pollResult.trace,
+    (parsed) => parsed?.activeFile === targetPath && parsed?.lastRenderedPath === targetPath && !parsed?.loading && parsed?.phase === 'idle' && !parsed?.activeStage,
+  );
+
+  return {
+    primaryDurationMs: trigger.durationMs + (viewSettledMs ?? options.pollTimeoutMs),
+    triggerDurationMs: trigger.durationMs,
+    firstResponsiveMs: firstResponsiveMs === null ? null : trigger.durationMs + firstResponsiveMs,
+    viewSettledMs: viewSettledMs === null ? null : trigger.durationMs + viewSettledMs,
+    backgroundDoneMs: backgroundDoneMs === null ? null : trigger.durationMs + backgroundDoneMs,
+    timeoutCount: pollResult.timeoutCount + (trigger.timedOut ? 1 : 0),
+    emptyPollCount: pollResult.emptyPollCount + (trigger.emptyOutput ? 1 : 0),
+    freezeDetected: pollResult.timeoutCount > 0 || pollResult.emptyPollCount > 0 || trigger.timedOut || trigger.emptyOutput,
+    trace: pollResult.trace,
+  };
+}
+
+async function sampleActiveLeafDebounce(vault, options, targetPath) {
+  await ensureConnectionsView(vault, options.timeoutMs);
+  const switchCode = `(async()=>{const path=${jsString(targetPath)}; const file=app.vault.getAbstractFileByPath(path); if(!file){return JSON.stringify({error:"missing-file", path});} const leaf=app.workspace.getMostRecentLeaf?.() ?? app.workspace.getLeaf(false); await leaf.openFile(file); return JSON.stringify({path});})()`;
+  await evalJson(vault, switchCode, options.timeoutMs);
+
+  let scheduledSeen = false;
+  const pollResult = await pollScenario({
+    vault,
+    timeoutMs: Math.max(options.pollTimeoutMs, 18_000),
+    pollIntervalMs: options.pollIntervalMs,
+    pollCodeFactory: () => `(() => {
+      const plugin = app.plugins.plugins["open-connections"];
+      return JSON.stringify({
+        activeFile: app.workspace.getActiveFile()?.path ?? null,
+        targetPath: ${jsString(targetPath)},
+        reImportScheduled: !!plugin?.re_import_timeout,
+        pendingCount: plugin?.pendingReImportPaths?.size ?? 0,
+        configuredWaitMs: (plugin?.settings?.re_import_wait_time ?? 13) * 1000,
+        phase: plugin?._embed_state?.phase ?? null,
+      });
+    })()`,
+    stopWhen: (entry) => {
+      const parsed = entry.parsed;
+      if (parsed?.reImportScheduled) scheduledSeen = true;
+      return !!parsed && scheduledSeen && parsed.activeFile === targetPath && parsed.reImportScheduled === false && parsed.pendingCount === 0;
+    },
+  });
+
+  const scheduledMs = firstMatchingElapsed(pollResult.trace, (parsed) => parsed?.reImportScheduled === true);
+  const clearedMs = firstMatchingElapsed(pollResult.trace, (parsed) => parsed?.activeFile === targetPath && parsed?.reImportScheduled === false && parsed?.pendingCount === 0);
+  const configuredWaitMs = pollResult.trace.find((entry) => entry.parsed?.configuredWaitMs)?.parsed?.configuredWaitMs ?? 13_000;
+
+  return {
+    primaryDurationMs: clearedMs ?? configuredWaitMs,
+    scheduledMs,
+    clearedMs,
+    configuredWaitMs,
+    timeoutCount: pollResult.timeoutCount,
+    emptyPollCount: pollResult.emptyPollCount,
+    freezeDetected: pollResult.timeoutCount > 0 || pollResult.emptyPollCount > 0,
+    trace: pollResult.trace,
+  };
+}
+
+async function sampleLookupOpen(vault, options) {
+  await closeLeavesOfType(vault, 'open-connections-lookup', options.timeoutMs);
+  const trigger = await runObsidian(vault, ['command', 'id=open-connections:open-lookup-view'], options.timeoutMs);
+  await evalJson(
+    vault,
+    `(async()=>{const leaf=app.workspace.getLeavesOfType("open-connections-lookup")[0]; if(leaf){ await app.workspace.revealLeaf(leaf); } return JSON.stringify({revealed:!!leaf});})()`,
+    options.timeoutMs,
+  );
+  await sleep(300);
+  const pollResult = await pollScenario({
+    vault,
+    timeoutMs: options.pollTimeoutMs,
+    pollIntervalMs: options.pollIntervalMs,
+    pollCodeFactory: () => `(() => JSON.stringify({
+      leafCount: app.workspace.getLeavesOfType("open-connections-lookup").length
+    }))()`,
+    stopWhen: (entry) => !!entry.parsed && (entry.parsed.leafCount ?? 0) > 0,
+  });
+
+  return {
+    primaryDurationMs: trigger.durationMs + (firstMatchingElapsed(pollResult.trace, (parsed) => (parsed?.leafCount ?? 0) > 0) ?? options.pollTimeoutMs),
+    triggerDurationMs: trigger.durationMs,
+    timeoutCount: pollResult.timeoutCount + (trigger.timedOut ? 1 : 0),
+    emptyPollCount: pollResult.emptyPollCount,
+    freezeDetected: pollResult.timeoutCount > 0 || pollResult.emptyPollCount > 0 || trigger.timedOut,
+    trace: pollResult.trace,
+  };
+}
+
+async function sampleLookupQuery(vault, options) {
+  await closeLeavesOfType(vault, 'open-connections-lookup', options.timeoutMs);
+  await ensureLookupView(vault, options.timeoutMs);
+  const query = options.query;
+  const searchCode = `(async()=>{const leaf=app.workspace.getLeavesOfType("open-connections-lookup")[0]; if(!leaf)return JSON.stringify({error:"lookup-view-missing"}); const view=leaf.view; view.searchInput.value=${jsString(query)}; view.performSearch(${jsString(query)}); return JSON.stringify({query:${jsString(query)}});})()`;
+  const trigger = await evalJson(vault, searchCode, options.timeoutMs);
+
+  const pollResult = await pollScenario({
+    vault,
+    timeoutMs: options.pollTimeoutMs,
+    pollIntervalMs: options.pollIntervalMs,
+    pollCodeFactory: () => `(() => {
+      const leaf = app.workspace.getLeavesOfType("open-connections-lookup")[0];
+      const view = leaf?.view;
+      const text = (view?.containerEl?.textContent ?? "").replace(/\\s+/g, " ").trim().slice(0, 400);
+      const resultsCount = view?.containerEl?.querySelectorAll?.(".osc-lookup-result")?.length ?? 0;
+      const loading = /Loading|Searching/.test(text);
+      return JSON.stringify({ resultsCount, loading, text });
+    })()`,
+    stopWhen: (entry) => !!entry.parsed && ((entry.parsed.resultsCount ?? 0) > 0 || (entry.parsed.loading === false && entry.parsed.text.length > 0)),
+  });
+
+  const lookupSettledMs = firstMatchingElapsed(
+    pollResult.trace,
+    (parsed) => (parsed?.resultsCount ?? 0) > 0 || (parsed?.loading === false && (parsed?.text ?? '').length > 0),
+  );
+
+  return {
+    primaryDurationMs: trigger.durationMs + (lookupSettledMs ?? options.pollTimeoutMs),
+    triggerDurationMs: trigger.durationMs,
+    lookupSettledMs: lookupSettledMs === null ? null : trigger.durationMs + lookupSettledMs,
+    timeoutCount: pollResult.timeoutCount + (trigger.timedOut ? 1 : 0),
+    emptyPollCount: pollResult.emptyPollCount + (trigger.emptyOutput ? 1 : 0),
+    freezeDetected: pollResult.timeoutCount > 0 || pollResult.emptyPollCount > 0 || trigger.timedOut || trigger.emptyOutput,
+    trace: pollResult.trace,
+  };
+}
+
+async function sampleSyntheticUnindexedNote(vault, options, sampleIndex) {
+  const notePath = `oc-state-latency-unindexed-${Date.now()}-${sampleIndex}.md`;
+  const noteContent = [
+    '# Unindexed latency sample',
+    '',
+    'This temporary note is intentionally imported as a source without blocks so that Connections View must perform the first block import on demand.',
+    '',
+    '## Section A',
+    'This section contains enough content to create a heading block and paragraph blocks during parsing. productivity obsidian semantic search embeddings background import connections view.',
+    '',
+    '## Section B',
+    'More content here so the parser, hashing work, and data adapter save are all exercised when the note is opened through Connections View.',
+  ].join('\n');
+
+  const primeCode = `(async()=>{const path=${jsString(notePath)}; const content=${jsString(noteContent)}; const plugin=app.plugins.plugins["open-connections"]; const existing=app.vault.getAbstractFileByPath(path); if(existing){await app.vault.delete(existing,true);} await app.vault.create(path, content); const file=app.vault.getAbstractFileByPath(path); const prev=plugin.source_collection._initializing; plugin.source_collection._initializing = true; try { await plugin.source_collection.import_source(file); await plugin.source_collection.data_adapter.save(); } finally { plugin.source_collection._initializing = prev; } plugin.pendingReImportPaths.delete(path); const blocks=plugin.block_collection.for_source(path); return JSON.stringify({path, sourceExists: !!plugin.source_collection.get(path), blockCount: blocks.length});})()`;
+  const primed = await evalJson(vault, primeCode, options.timeoutMs);
+  if (!primed.parsed?.sourceExists || primed.parsed?.blockCount !== 0) {
+    throw new Error('Failed to prime a synthetic unindexed note for state-latency profiling.');
+  }
+
+  const sample = await sampleNoteSwitch(vault, options, notePath);
+
+  const cleanupCode = `(async()=>{const path=${jsString(notePath)}; const plugin=app.plugins.plugins["open-connections"]; plugin.pendingReImportPaths.delete(path); plugin.block_collection?.delete_source_blocks?.(path); plugin.source_collection?.delete?.(path); const file=app.vault.getAbstractFileByPath(path); if(file){await app.vault.delete(file,true);} return JSON.stringify({deleted:path});})()`;
+  await evalJson(vault, cleanupCode, options.timeoutMs);
+
+  return sample;
+}
+
+function summarizeRepeated(state, samples) {
+  return summarizeLatencyState(state, samples.map((sample) => ({
+    ...sample,
+  })));
+}
+
+function buildMarkdownReport(summary) {
+  const lines = [
+    '# Ataraxia State Latency Report',
+    '',
+    `- Generated: ${summary.generatedAt}`,
+    `- Vault: ${summary.options.vault}`,
+    `- Samples per repeated interactive state: ${summary.options.samples}`,
+    '',
+    '| State | Samples | Median / Worst | Trigger median | Impact | Empty / Timeout polls | Code path | What it means |',
+    '|---|---:|---:|---:|---|---:|---|---|',
+  ];
+
+  for (const state of summary.states) {
+    const stats = `${state.medianMs ?? 'n/a'} / ${state.worstCaseMs ?? 'n/a'} ms`;
+    const triggerStats = state.triggerMedianMs === null ? 'n/a' : `${state.triggerMedianMs} ms`;
+    lines.push(`| ${state.label} | ${state.sampleCount} | ${stats} | ${triggerStats} | ${state.impact} | ${state.emptyPollCount} / ${state.timeoutCount} | ${state.codePath.join('<br>')} | ${state.explanation} |`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  mkdirSync(options.artifactDir, { recursive: true });
+
+  const candidates = await getCandidateNotes(options.vault, options.samples, Math.max(options.timeoutMs, 15_000));
+  const indexedCandidates = (candidates.indexed ?? []).filter((path) => path !== candidates.activeFile);
+  const fallbackIndexedCandidates = indexedCandidates.length > 0 ? indexedCandidates : (candidates.indexed ?? []);
+
+  if (fallbackIndexedCandidates.length === 0) {
+    throw new Error('No indexed-note candidates available for state-latency profiling.');
+  }
+  const startup = await captureStartupStages(options.vault, options);
+  const newNoteSamples = [];
+  const indexedSamples = [];
+  const unindexedSamples = [];
+  const activeLeafSamples = [];
+  const lookupOpenSamples = [];
+  const lookupQuerySamples = [];
+
+  for (let index = 0; index < options.samples; index += 1) {
+    newNoteSamples.push(await sampleNewNote(options.vault, options, index));
+    indexedSamples.push(await sampleNoteSwitch(options.vault, options, fallbackIndexedCandidates[index % fallbackIndexedCandidates.length]));
+    unindexedSamples.push(await sampleSyntheticUnindexedNote(options.vault, options, index));
+    activeLeafSamples.push(await sampleActiveLeafDebounce(options.vault, options, fallbackIndexedCandidates[index % fallbackIndexedCandidates.length]));
+    lookupOpenSamples.push(await sampleLookupOpen(options.vault, options));
+    lookupQuerySamples.push(await sampleLookupQuery(options.vault, options));
+  }
+
+  const states = [
+    summarizeLatencyState(STATE_DEFS.startupCore, startup.states[0].samples),
+    summarizeLatencyState(STATE_DEFS.startupEmbedding, startup.states[1].samples),
+    summarizeLatencyState(STATE_DEFS.startupBackgroundImport, startup.states[2].samples),
+    summarizeRepeated(STATE_DEFS.newNote, newNoteSamples),
+    summarizeRepeated(STATE_DEFS.noteSwitchIndexed, indexedSamples),
+    summarizeRepeated(STATE_DEFS.noteSwitchUnindexed, unindexedSamples),
+    summarizeRepeated(STATE_DEFS.activeLeafDebounce, activeLeafSamples),
+    summarizeRepeated(STATE_DEFS.lookupOpen, lookupOpenSamples),
+    summarizeRepeated(STATE_DEFS.lookupFirstQuery, lookupQuerySamples),
+  ];
+
+  const summary = {
+    generatedAt: nowIso(),
+    options,
+    candidates,
+    states,
+    raw: {
+      startup: startup.raw,
+      newNoteSamples,
+      indexedSamples,
+      unindexedSamples,
+      activeLeafSamples,
+      lookupOpenSamples,
+      lookupQuerySamples,
+    },
+  };
+
+  const artifactBase = resolve(options.artifactDir, `${stamp()}-state-latency`);
+  const jsonPath = `${artifactBase}.json`;
+  const mdPath = `${artifactBase}.md`;
+  writeFileSync(jsonPath, JSON.stringify(summary, null, 2));
+  writeFileSync(mdPath, buildMarkdownReport(summary));
+
+  console.log(JSON.stringify({
+    jsonPath,
+    mdPath,
+    states: states.map((state) => ({
+      id: state.id,
+      medianMs: state.medianMs,
+      worstCaseMs: state.worstCaseMs,
+      impact: state.impact,
+    })),
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exit(1);
+});

--- a/src/domain/connections/render-orchestration.ts
+++ b/src/domain/connections/render-orchestration.ts
@@ -1,0 +1,19 @@
+import type { ConnectionResult } from '../../types/entities';
+import { ConnectionsResultCache } from './result-cache';
+
+export type RenderDecision =
+  | { kind: 'serve_cached'; results: readonly ConnectionResult[] }
+  | { kind: 'compute_fresh' }
+  | { kind: 'revalidate_in_background'; staleResults: readonly ConnectionResult[] };
+
+export function decideRender(
+  input: { path: string; fingerprint: string; kernelPhase: 'idle' | 'running' | 'error' },
+  cache: ConnectionsResultCache,
+): RenderDecision {
+  const cached = cache.get(input.path, input.fingerprint);
+  if (!cached) return { kind: 'compute_fresh' };
+  if (input.kernelPhase === 'running') {
+    return { kind: 'revalidate_in_background', staleResults: cached };
+  }
+  return { kind: 'serve_cached', results: cached };
+}

--- a/src/domain/connections/result-cache.ts
+++ b/src/domain/connections/result-cache.ts
@@ -1,0 +1,41 @@
+import type { ConnectionResult } from '../../types/entities';
+
+const DEFAULT_MAX_ENTRIES = 64;
+
+interface CachedEntry {
+  fingerprint: string;
+  results: readonly ConnectionResult[];
+}
+
+export class ConnectionsResultCache {
+  private readonly store = new Map<string, CachedEntry>();
+
+  constructor(private readonly maxEntries: number = DEFAULT_MAX_ENTRIES) {}
+
+  get(path: string, fingerprint: string): readonly ConnectionResult[] | null {
+    const entry = this.store.get(path);
+    if (!entry || entry.fingerprint !== fingerprint) return null;
+
+    this.store.delete(path);
+    this.store.set(path, entry);
+    return entry.results;
+  }
+
+  set(path: string, fingerprint: string, results: readonly ConnectionResult[]): void {
+    if (this.store.has(path)) this.store.delete(path);
+    this.store.set(path, { fingerprint, results });
+
+    if (this.store.size > this.maxEntries) {
+      const oldestKey = this.store.keys().next().value as string | undefined;
+      if (oldestKey) this.store.delete(oldestKey);
+    }
+  }
+
+  invalidate(path: string): void {
+    this.store.delete(path);
+  }
+
+  invalidateAll(): void {
+    this.store.clear();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import type { EmbedQueueStats, EmbeddingPipeline } from './domain/embedding-pipe
 import type { BlockCollection, SourceCollection } from './domain/entities';
 import type { EmbeddingKernelJob } from './domain/embedding-kernel-types';
 import type { PluginSettings } from './types/settings';
+import type { ConnectionsReader } from './types/connections-reader';
 import type {
   EmbedProfilingState,
   EmbedProgressEventPayload,
@@ -62,6 +63,7 @@ import {
   waitForSync as _waitForSync,
 } from './ui/plugin-initialization';
 import { createEmbedProfilingState } from './ui/embed-profiling-state';
+import { createConnectionsReader } from './ui/connections-reader-adapter';
 import {
   resetEmbedError as _resetEmbedError,
   setEmbedPhase as _setEmbedPhase,
@@ -111,6 +113,7 @@ export default class SmartConnectionsPlugin extends Plugin {
   embedding_job_queue?: EmbeddingKernelJobQueue;
   pendingReImportPaths = new Set<string>();
   mcp_server?: OpenConnectionsMcpServer;
+  private _connectionsReader?: ConnectionsReader;
   _lifecycle_epoch = 0;
   _embed_state: EmbedStateSnapshot = { phase: 'idle', modelFingerprint: null, lastError: null };
   _embed_profiling: EmbedProfilingState = createEmbedProfilingState();
@@ -131,6 +134,10 @@ export default class SmartConnectionsPlugin extends Plugin {
   }
 
   get embed_ready(): boolean { return isEmbedModelReady(this.getEmbedRuntimeState()); }
+  get connectionsReader(): ConnectionsReader {
+    if (!this._connectionsReader) this._connectionsReader = createConnectionsReader(this);
+    return this._connectionsReader;
+  }
   get search_embed_model(): EmbedModelAdapter | undefined { return this._search_embed_model ?? this.embed_adapter; }
   get status_state(): 'idle' | 'embedding' | 'error' { return toLegacyStatusState(this.getEmbedRuntimeState()); }
   getEmbedProfilingState(): EmbedProfilingState {

--- a/src/types/connections-reader.ts
+++ b/src/types/connections-reader.ts
@@ -1,0 +1,18 @@
+import type { ParsedEmbedRuntimeState, EmbedStatePhase } from './embed-runtime';
+import type { ConnectionResult } from './entities';
+import type { EmbeddingBlockLike, EmbeddingSourceLike } from './obsidian-shims';
+
+export interface ConnectionsReader {
+  isReady(): boolean;
+  isEmbedReady(): boolean;
+  getStatusState(): string;
+  hasPendingReImport(path: string): boolean;
+  getBlocksForSource(path: string): EmbeddingBlockLike[];
+  getSource(path: string): EmbeddingSourceLike | null;
+  ensureBlocksForSource(path: string): Promise<readonly EmbeddingBlockLike[]>;
+  getConnectionsForSource(path: string, limit?: number): Promise<readonly ConnectionResult[]>;
+  getEmbedRuntimeState(): ParsedEmbedRuntimeState | null;
+  getSearchModelFingerprint(): string | null;
+  getKernelPhase(): EmbedStatePhase;
+  isDiscovering(): boolean;
+}

--- a/src/types/obsidian-shims.ts
+++ b/src/types/obsidian-shims.ts
@@ -71,3 +71,19 @@ export interface CachedMetadataShim {
 export interface MetadataCacheShim {
   getFileCache(file: TFileShim): CachedMetadataShim | null;
 }
+
+export interface EmbeddingBlockLike {
+  has_embed(): boolean;
+  key?: string;
+  source_key?: string;
+  queue_embed?(): void;
+}
+
+export interface EmbeddingSourceLike {
+  key: string;
+  path: string;
+  file?: TFileShim;
+  vault?: VaultShim;
+  cached_metadata?: CachedMetadataShim;
+  read?(): Promise<string>;
+}

--- a/src/ui/ConnectionsView.ts
+++ b/src/ui/ConnectionsView.ts
@@ -2,6 +2,9 @@ import { ItemView, Workspace, WorkspaceLeaf, TFile } from 'obsidian';
 
 import type SmartConnectionsPlugin from '../main';
 import type { ConnectionResult } from '../types/entities';
+import type { ConnectionsReader } from '../types/connections-reader';
+import { ConnectionsResultCache } from '../domain/connections/result-cache';
+import { decideRender } from '../domain/connections/render-orchestration';
 import { applyConnectionsViewState, deriveConnectionsViewState, scheduleConnectionsRetry } from './connections-view-state';
 import {
   cancelPendingRetry,
@@ -32,11 +35,14 @@ export const CONNECTIONS_VIEW_TYPE = 'open-connections-view';
 
 export class ConnectionsView extends ItemView {
   plugin: SmartConnectionsPlugin;
+  reader: ConnectionsReader;
+  resultsCache = new ConnectionsResultCache();
   container: HTMLElement;
   session: ConnectionsSessionState = { pinnedKeys: [], hiddenKeys: [], paused: false };
   folderFilter = '';
   embedProgress: { update(): void; destroy(): void } | null = null;
   lastRenderedPath: string | null = null;
+  lastSearchFingerprint: string | null = null;
   autoEmbedRequestedForPath: string | null = null;
   _autoEmbedTimeout: number | null = null;
   _needsRefresh = false;
@@ -45,9 +51,10 @@ export class ConnectionsView extends ItemView {
   _lastResultKeys: string[] = [];
   _pendingRetry: number | null = null;
 
-  constructor(leaf: WorkspaceLeaf, plugin: SmartConnectionsPlugin) {
+  constructor(leaf: WorkspaceLeaf, plugin: SmartConnectionsPlugin, reader: ConnectionsReader) {
     super(leaf);
     this.plugin = plugin;
+    this.reader = reader;
     this.navigation = false;
     loadConnectionsSession(this);
   }
@@ -84,6 +91,7 @@ export class ConnectionsView extends ItemView {
       this.updateProgressBanner();
       if (payload?.prev === 'running' && payload?.phase === 'idle' && this.lastRenderedPath) {
         invalidateConnectionsCache();
+        this.resultsCache.invalidate(this.lastRenderedPath);
         this.autoEmbedRequestedForPath = null;
         this.clearAutoEmbedTimeout();
         void this.renderView(this.lastRenderedPath);
@@ -114,7 +122,7 @@ export class ConnectionsView extends ItemView {
   async renderView(targetPath?: string): Promise<void> {
     const gen = ++this._renderGen;
     if (!this.container) return;
-    if ((this.plugin as unknown as { _discovering?: boolean })._discovering) {
+    if (this.reader.isDiscovering()) {
       this._needsRefresh = true;
       return;
     }
@@ -129,6 +137,47 @@ export class ConnectionsView extends ItemView {
       return;
     }
     this.lastRenderedPath = targetPath;
+    const fingerprint = this.reader.getSearchModelFingerprint();
+    const hasPendingReImport = this.reader.hasPendingReImport(targetPath);
+
+    if (hasPendingReImport) {
+      this.resultsCache.invalidate(targetPath);
+      invalidateConnectionsCache(targetPath);
+    }
+
+    if (fingerprint !== this.lastSearchFingerprint) {
+      if (this.lastSearchFingerprint !== null) {
+        this.resultsCache.invalidateAll();
+        invalidateConnectionsCache();
+        this.lastRenderFingerprint = null;
+        this.showLoading('Embedding model changed. Re-embedding in progress.');
+      }
+      this.lastSearchFingerprint = fingerprint;
+    }
+
+    if (!fingerprint) {
+      this.resultsCache.invalidate(targetPath);
+      invalidateConnectionsCache(targetPath);
+    }
+
+    if (fingerprint) {
+      const decision = decideRender(
+        { path: targetPath, fingerprint, kernelPhase: this.reader.getKernelPhase() },
+        this.resultsCache,
+      );
+      if (decision.kind === 'serve_cached') {
+        if (this.scheduleRetryIfStale(gen)) return;
+        this.applyViewState({ type: 'results', path: targetPath, results: [...decision.results] });
+        this.updateProgressBanner();
+        return;
+      }
+      if (decision.kind === 'revalidate_in_background') {
+        if (this.scheduleRetryIfStale(gen)) return;
+        this.applyViewState({ type: 'results', path: targetPath, results: [...decision.staleResults] });
+        this.updateProgressBanner();
+        return;
+      }
+    }
 
     try {
       bumpEmbedProfilingCounter(this.plugin, 'connectionsViewRenderCount');
@@ -136,6 +185,9 @@ export class ConnectionsView extends ItemView {
         return await this.deriveViewState(targetPath);
       });
       if (this.scheduleRetryIfStale(gen)) return;
+      if (state.type === 'results' && fingerprint) {
+        this.resultsCache.set(targetPath, fingerprint, state.results);
+      }
       this.applyViewState(state);
       this.updateProgressBanner();
     } catch (error) {

--- a/src/ui/connections-reader-adapter.ts
+++ b/src/ui/connections-reader-adapter.ts
@@ -1,0 +1,43 @@
+import type SmartConnectionsPlugin from '../main';
+import { getBlockConnections } from './block-connections';
+import type { ConnectionsReader } from '../types/connections-reader';
+
+const DEFAULT_KERNEL_PHASE = 'idle';
+
+function getAdapterFingerprint(plugin: SmartConnectionsPlugin): string | null {
+  const runtimeFingerprint = plugin.getEmbedRuntimeState?.()?.snapshot?.modelFingerprint;
+  if (runtimeFingerprint) return runtimeFingerprint;
+
+  const searchAdapter = plugin._search_embed_model as { fingerprint?: string } | undefined;
+  return searchAdapter?.fingerprint ?? null;
+}
+
+export function createConnectionsReader(plugin: SmartConnectionsPlugin): ConnectionsReader {
+  return {
+    isReady: () => Boolean(plugin.ready && plugin.block_collection),
+    isEmbedReady: () => Boolean(plugin.embed_ready),
+    getStatusState: () => plugin.status_state ?? '',
+    hasPendingReImport: (path) => plugin.pendingReImportPaths?.has(path) ?? false,
+    getBlocksForSource: (path) => plugin.block_collection?.for_source(path) ?? [],
+    getSource: (path) => plugin.source_collection?.get(path) ?? null,
+    ensureBlocksForSource: async (path: string) => {
+      const blocks = plugin.block_collection?.for_source(path) ?? [];
+      if (blocks.length > 0) return blocks;
+
+      const source = plugin.source_collection?.get(path) ?? null;
+      if (!source || !plugin.block_collection) return [];
+
+      await plugin.block_collection.import_source_blocks(source);
+      await plugin.block_collection.data_adapter.save();
+      return plugin.block_collection.for_source(path);
+    },
+    getConnectionsForSource: async (path: string, limit = 50) => {
+      if (!plugin.block_collection) return [];
+      return await getBlockConnections(plugin.block_collection, path, { limit });
+    },
+    getEmbedRuntimeState: () => plugin.getEmbedRuntimeState?.() ?? null,
+    getSearchModelFingerprint: () => getAdapterFingerprint(plugin),
+    getKernelPhase: () => plugin.getEmbedRuntimeState?.()?.snapshot?.phase ?? plugin._embed_state?.phase ?? DEFAULT_KERNEL_PHASE,
+    isDiscovering: () => Boolean((plugin as SmartConnectionsPlugin & { _discovering?: boolean })._discovering),
+  };
+}

--- a/src/ui/connections-view-auto-embed.ts
+++ b/src/ui/connections-view-auto-embed.ts
@@ -1,9 +1,9 @@
-import type { EmbeddingBlock } from '../domain/entities/EmbeddingBlock';
+import type { EmbeddingBlockLike } from '../types/obsidian-shims';
 import type { ConnectionsView } from './ConnectionsView';
 
-export function enqueueBlocksForEmbedding(blocks: EmbeddingBlock[]): void {
+export function enqueueBlocksForEmbedding(blocks: readonly EmbeddingBlockLike[]): void {
   for (const block of blocks) {
-    block.queue_embed();
+    block.queue_embed?.();
   }
 }
 
@@ -13,7 +13,7 @@ export function clearAutoEmbedTimeout(view: ConnectionsView): void {
   view._autoEmbedTimeout = null;
 }
 
-export function autoQueueBlockEmbedding(view: ConnectionsView, blocks: EmbeddingBlock[]): void {
+export function autoQueueBlockEmbedding(view: ConnectionsView, blocks: readonly EmbeddingBlockLike[]): void {
   if (!view.plugin.embed_ready) return;
   const firstKey = blocks[0]?.key;
   if (!firstKey) return;

--- a/src/ui/connections-view-progress.ts
+++ b/src/ui/connections-view-progress.ts
@@ -30,10 +30,12 @@ export function handleConnectionsModelSwitched(view: ConnectionsView): void {
   clearEmbedProgress(view);
   clearConnectionsBanner(view);
   invalidateConnectionsCache();
+  view.resultsCache.invalidateAll();
   view.container.empty();
   addConnectionsBanner(view, 'Embedding model changed. Re-embedding in progress.');
   view.lastRenderedPath = null;
   view.lastRenderFingerprint = null;
+  view.lastSearchFingerprint = null;
   view._lastResultKeys = [];
   view.autoEmbedRequestedForPath = null;
 }

--- a/src/ui/connections-view-state.ts
+++ b/src/ui/connections-view-state.ts
@@ -1,5 +1,4 @@
 import type { ConnectionResult } from '../types/entities';
-import { getBlockConnections } from './block-connections';
 import { autoQueueBlockEmbedding } from './connections-view-auto-embed';
 import type { ConnectionsView } from './ConnectionsView';
 
@@ -22,33 +21,28 @@ export async function deriveConnectionsViewState(
   view: ConnectionsView,
   targetPath: string,
 ): Promise<ViewState> {
-  if (!view.plugin.ready || !view.plugin.block_collection) {
+  const reader = view.reader;
+
+  if (!reader.isReady()) {
     return { type: 'plugin_loading' };
   }
 
-  let allFileBlocks = view.plugin.block_collection.for_source(targetPath);
-  if (allFileBlocks.length === 0) {
-    if (view.plugin.pendingReImportPaths.has(targetPath)) {
-      return { type: 'pending_import', path: targetPath };
-    }
-    const source = view.plugin.source_collection?.get(targetPath);
-    if (source) {
-      await view.plugin.block_collection.import_source_blocks(source);
-      await view.plugin.block_collection.data_adapter.save();
-      allFileBlocks = view.plugin.block_collection.for_source(targetPath);
-    }
-    if (allFileBlocks.length === 0) return { type: 'note_too_short' };
+  if (reader.hasPendingReImport(targetPath)) {
+    return { type: 'pending_import', path: targetPath };
   }
+
+  const allFileBlocks = await reader.ensureBlocksForSource(targetPath);
+  if (allFileBlocks.length === 0) return { type: 'note_too_short' };
 
   const embedded = allFileBlocks.filter((block) => block.has_embed());
   if (embedded.length > 0) {
-    const results = await getBlockConnections(view.plugin.block_collection, targetPath, { limit: 50 });
+    const results = await reader.getConnectionsForSource(targetPath, 50);
     return results.length === 0
       ? { type: 'no_connections' }
-      : { type: 'results', path: targetPath, results };
+      : { type: 'results', path: targetPath, results: [...results] };
   }
 
-  const runtime = view.plugin.getEmbedRuntimeState?.() ?? null;
+  const runtime = reader.getEmbedRuntimeState();
   if (runtime) {
     switch (runtime.serving.kind) {
       case 'unavailable':
@@ -62,8 +56,8 @@ export async function deriveConnectionsViewState(
     }
   }
 
-  if (view.plugin.status_state === 'error') return { type: 'model_error' };
-  if (!view.plugin.embed_ready) return { type: 'embed_loading' };
+  if (reader.getStatusState() === 'error') return { type: 'model_error' };
+  if (!reader.isEmbedReady()) return { type: 'embed_loading' };
 
   autoQueueBlockEmbedding(view, allFileBlocks);
   return { type: 'embedding_in_progress', path: targetPath };

--- a/src/ui/plugin-registration.ts
+++ b/src/ui/plugin-registration.ts
@@ -6,9 +6,11 @@ import { registerSmartConnectionsCodeBlock } from './plugin-codeblock';
 import { SmartConnectionsSettingsTab } from './settings';
 
 export function registerPluginUi(plugin: SmartConnectionsPlugin): void {
-  plugin.registerView(CONNECTIONS_VIEW_TYPE, (leaf) => new ConnectionsView(leaf, plugin));
+  const reader = plugin.connectionsReader;
+
+  plugin.registerView(CONNECTIONS_VIEW_TYPE, (leaf) => new ConnectionsView(leaf, plugin, reader));
   plugin.registerView(LOOKUP_VIEW_TYPE, (leaf) => new LookupView(leaf, plugin));
-  plugin.registerView('smart-connections-view', (leaf) => new ConnectionsView(leaf, plugin));
+  plugin.registerView('smart-connections-view', (leaf) => new ConnectionsView(leaf, plugin, reader));
   plugin.registerView('smart-connections-lookup', (leaf) => new LookupView(leaf, plugin));
 
   plugin.addSettingTab(new SmartConnectionsSettingsTab(plugin.app, plugin));

--- a/test/connections-reader-adapter.test.ts
+++ b/test/connections-reader-adapter.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { invalidateConnectionsCache } from '../src/ui/block-connections';
+import { createConnectionsReader } from '../src/ui/connections-reader-adapter';
+
+describe('createConnectionsReader', () => {
+  beforeEach(() => invalidateConnectionsCache());
+  const fakePlugin = {
+    ready: true,
+    embed_ready: false,
+    status_state: 'ok',
+    pendingReImportPaths: new Set(['a.md']),
+    block_collection: {
+      for_source: (path: string) => (path === 'x.md' ? [{ has_embed: () => true, key: 'x.md#h1', source_key: 'x.md', vec: [1, 2, 3], evictVec: () => undefined }] : []),
+      ensure_entity_vector: async () => {},
+      nearest: async () => [{ item: { key: 'other.md#h1', source_key: 'other.md', evictVec: () => undefined }, score: 0.9 }],
+    },
+    source_collection: {
+      get: (path: string) => (path === 'x.md' ? { key: 'x.md', path: 'x.md' } : null),
+    },
+    getEmbedRuntimeState: () => ({ serving: { kind: 'ready' } }),
+    _search_embed_model: { fingerprint: 'fp-1' },
+    _embed_state: { phase: 'running' },
+    _discovering: true,
+  } as any;
+
+  it('exposes plugin reads through the reader surface', async () => {
+    const reader = createConnectionsReader(fakePlugin);
+
+    expect(reader.isReady()).toBe(true);
+    expect(reader.isEmbedReady()).toBe(false);
+    expect(reader.getStatusState()).toBe('ok');
+    expect(reader.hasPendingReImport('a.md')).toBe(true);
+    expect(reader.hasPendingReImport('b.md')).toBe(false);
+    expect(reader.getBlocksForSource('x.md')).toHaveLength(1);
+    expect(reader.getSource('x.md')?.path).toBe('x.md');
+    expect(reader.getEmbedRuntimeState()).toEqual({ serving: { kind: 'ready' } });
+    expect(await reader.getConnectionsForSource('x.md', 25)).toEqual([{ item: { key: 'other.md#h1', source_key: 'other.md', evictVec: expect.any(Function) }, score: 0.9 }]);
+    expect(reader.getSearchModelFingerprint()).toBe('fp-1');
+    expect(reader.getKernelPhase()).toBe('running');
+    expect(reader.isDiscovering()).toBe(true);
+  });
+
+  it('returns safe defaults when optional fields are absent', async () => {
+    const reader = createConnectionsReader({ ready: false, _embed_state: { phase: 'idle' } } as any);
+
+    expect(reader.isReady()).toBe(false);
+    expect(reader.isEmbedReady()).toBe(false);
+    expect(reader.getStatusState()).toBe('');
+    expect(reader.hasPendingReImport('missing.md')).toBe(false);
+    expect(reader.getBlocksForSource('missing.md')).toEqual([]);
+    expect(reader.getSource('missing.md')).toBeNull();
+    expect(reader.getEmbedRuntimeState()).toBeNull();
+    expect(await reader.getConnectionsForSource('missing.md')).toEqual([]);
+    expect(reader.getSearchModelFingerprint()).toBeNull();
+    expect(reader.getKernelPhase()).toBe('idle');
+    expect(reader.isDiscovering()).toBe(false);
+  });
+});

--- a/test/connections-reader.types.test.ts
+++ b/test/connections-reader.types.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { ConnectionsReader } from '../src/types/connections-reader';
+
+describe('ConnectionsReader port', () => {
+  it('exposes read-only methods and no mutators', () => {
+    expectTypeOf<ConnectionsReader['isReady']>().toEqualTypeOf<() => boolean>();
+    expectTypeOf<ConnectionsReader['hasPendingReImport']>().toEqualTypeOf<(path: string) => boolean>();
+    expectTypeOf<ConnectionsReader['ensureBlocksForSource']>().toEqualTypeOf<(path: string) => Promise<readonly import('../src/types/obsidian-shims').EmbeddingBlockLike[]>>();
+    expectTypeOf<ConnectionsReader['getConnectionsForSource']>().toEqualTypeOf<(path: string, limit?: number) => Promise<readonly import('../src/types/entities').ConnectionResult[]>>();
+    // @ts-expect-error mutators must not exist on the reader
+    type NoMutator = ConnectionsReader['importSourceBlocks'];
+  });
+});

--- a/test/connections-render-orchestration.test.ts
+++ b/test/connections-render-orchestration.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { ConnectionsResultCache } from '../src/domain/connections/result-cache';
+import { decideRender } from '../src/domain/connections/render-orchestration';
+
+describe('decideRender', () => {
+  it('returns compute_fresh when there is no exact cache hit', () => {
+    const cache = new ConnectionsResultCache();
+
+    expect(decideRender({ path: 'note.md', fingerprint: 'fp-1', kernelPhase: 'idle' }, cache)).toEqual({ kind: 'compute_fresh' });
+  });
+
+  it('returns serve_cached when there is an exact cache hit and the kernel is idle', () => {
+    const cache = new ConnectionsResultCache();
+    const results = [{ item: { key: 'other.md#A' }, score: 0.9 }] as const;
+    cache.set('note.md', 'fp-1', results);
+
+    expect(decideRender({ path: 'note.md', fingerprint: 'fp-1', kernelPhase: 'idle' }, cache)).toEqual({ kind: 'serve_cached', results });
+  });
+
+  it('returns revalidate_in_background when there is an exact cache hit and the kernel is running', () => {
+    const cache = new ConnectionsResultCache();
+    const results = [{ item: { key: 'other.md#A' }, score: 0.9 }] as const;
+    cache.set('note.md', 'fp-1', results);
+
+    expect(decideRender({ path: 'note.md', fingerprint: 'fp-1', kernelPhase: 'running' }, cache)).toEqual({ kind: 'revalidate_in_background', staleResults: results });
+  });
+});

--- a/test/connections-result-cache.test.ts
+++ b/test/connections-result-cache.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { ConnectionsResultCache } from '../src/domain/connections/result-cache';
+
+describe('ConnectionsResultCache', () => {
+  it('returns null when no entry exists for the path', () => {
+    const cache = new ConnectionsResultCache();
+
+    expect(cache.get('note.md', 'fp-1')).toBeNull();
+  });
+
+  it('returns cached results only for an exact path + fingerprint match', () => {
+    const cache = new ConnectionsResultCache();
+    const results = [{ item: { key: 'other.md#A' }, score: 0.9 }] as const;
+
+    cache.set('note.md', 'fp-1', results);
+
+    expect(cache.get('note.md', 'fp-1')).toEqual(results);
+    expect(cache.get('note.md', 'fp-2')).toBeNull();
+    expect(cache.get('other.md', 'fp-1')).toBeNull();
+  });
+
+
+  it('replaces an existing path entry instead of keeping stale results', () => {
+    const cache = new ConnectionsResultCache();
+    const initial = [{ item: { key: 'old.md#A' }, score: 0.4 }];
+    const updated = [{ item: { key: 'new.md#B' }, score: 0.95 }];
+
+    cache.set('note.md', 'fp-1', initial);
+    cache.set('note.md', 'fp-1', updated);
+
+    expect(cache.get('note.md', 'fp-1')).toEqual(updated);
+  });
+
+  it('invalidates only the specified path', () => {
+    const cache = new ConnectionsResultCache();
+    const noteResults = [{ item: { key: 'other.md#A' }, score: 0.9 }];
+    const otherResults = [{ item: { key: 'third.md#B' }, score: 0.8 }];
+
+    cache.set('note.md', 'fp-1', noteResults);
+    cache.set('other.md', 'fp-1', otherResults);
+
+    cache.invalidate('note.md');
+
+    expect(cache.get('note.md', 'fp-1')).toBeNull();
+    expect(cache.get('other.md', 'fp-1')).toEqual(otherResults);
+  });
+
+  it('invalidates all cached paths', () => {
+    const cache = new ConnectionsResultCache();
+
+    cache.set('note.md', 'fp-1', [{ item: { key: 'other.md#A' }, score: 0.9 }]);
+    cache.set('other.md', 'fp-2', [{ item: { key: 'third.md#B' }, score: 0.8 }]);
+
+    cache.invalidateAll();
+
+    expect(cache.get('note.md', 'fp-1')).toBeNull();
+    expect(cache.get('other.md', 'fp-2')).toBeNull();
+  });
+
+  it('evicts the least-recently-used entry once the cache exceeds its max size', () => {
+    const cache = new ConnectionsResultCache();
+
+    for (let index = 0; index < 64; index += 1) {
+      cache.set(`note-${index}.md`, 'fp-1', [{ item: { key: `result-${index}` }, score: index }]);
+    }
+
+    cache.set('overflow.md', 'fp-1', [{ item: { key: 'result-overflow' }, score: 999 }]);
+
+    expect(cache.get('note-0.md', 'fp-1')).toBeNull();
+    expect(cache.get('overflow.md', 'fp-1')).toEqual([{ item: { key: 'result-overflow' }, score: 999 }]);
+  });
+
+  it('treats a cache hit as recent for LRU eviction', () => {
+    const cache = new ConnectionsResultCache();
+
+    for (let index = 0; index < 64; index += 1) {
+      cache.set(`note-${index}.md`, 'fp-1', [{ item: { key: `result-${index}` }, score: index }]);
+    }
+
+    expect(cache.get('note-0.md', 'fp-1')).toEqual([{ item: { key: 'result-0' }, score: 0 }]);
+
+    cache.set('overflow.md', 'fp-1', [{ item: { key: 'result-overflow' }, score: 999 }]);
+
+    expect(cache.get('note-0.md', 'fp-1')).toEqual([{ item: { key: 'result-0' }, score: 0 }]);
+    expect(cache.get('note-1.md', 'fp-1')).toBeNull();
+  });
+});

--- a/test/connections-view-results.test.ts
+++ b/test/connections-view-results.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { ConnectionsView } from '../src/ui/ConnectionsView';
+import { createConnectionsReader } from '../src/ui/connections-reader-adapter';
 
 function createPluginStub() {
   return {
@@ -85,7 +86,9 @@ function createObsidianLikeContainer(): any {
 describe('ConnectionsView render cache', () => {
   it('re-renders when folderFilter changes even if raw results are unchanged', () => {
     const plugin = createPluginStub();
-    const view = new ConnectionsView({} as any, plugin);
+    const reader = plugin.connectionsReader ?? createConnectionsReader(plugin);
+  plugin.connectionsReader = reader;
+  const view = new ConnectionsView({} as any, plugin, reader);
     (view as any).container = createObsidianLikeContainer();
     (view as any).registerDomEvent = vi.fn();
 

--- a/test/connections-view-session.test.ts
+++ b/test/connections-view-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ConnectionsView } from '../src/ui/ConnectionsView';
+import { createConnectionsReader } from '../src/ui/connections-reader-adapter';
 
 function createPluginStub() {
   return {
@@ -111,7 +112,9 @@ describe('ConnectionsView rendering states', () => {
       { item: { key: 'other.md#Topic', source_key: 'other.md' }, score: 0.9 },
     ]);
 
-    const view = new ConnectionsView({} as any, plugin);
+    const reader = plugin.connectionsReader ?? createConnectionsReader(plugin);
+  plugin.connectionsReader = reader;
+  const view = new ConnectionsView({} as any, plugin, reader);
     (view as any).container = createObsidianLikeContainer();
 
     await view.renderView('note.md');
@@ -134,7 +137,9 @@ describe('ConnectionsView rendering states', () => {
     plugin.block_collection.all = [unembeddedBlock];
     plugin.runEmbeddingJob = vi.fn(async () => ({}));
 
-    const view = new ConnectionsView({} as any, plugin);
+    const reader = plugin.connectionsReader ?? createConnectionsReader(plugin);
+  plugin.connectionsReader = reader;
+  const view = new ConnectionsView({} as any, plugin, reader);
     (view as any).container = createObsidianLikeContainer();
 
     await view.renderView('note.md');
@@ -161,7 +166,9 @@ describe('ConnectionsView rendering states', () => {
       { item: { key: 'other.md#Topic', source_key: 'other.md' }, score: 0.9 },
     ]);
 
-    const view = new ConnectionsView({} as any, plugin);
+    const reader = plugin.connectionsReader ?? createConnectionsReader(plugin);
+  plugin.connectionsReader = reader;
+  const view = new ConnectionsView({} as any, plugin, reader);
     (view as any).container = createObsidianLikeContainer();
 
     await view.renderView('failed-note.md');
@@ -193,7 +200,9 @@ describe('ConnectionsView rendering states', () => {
     };
     plugin.block_collection.all = [unembeddedBlock];
 
-    const view = new ConnectionsView({} as any, plugin);
+    const reader = plugin.connectionsReader ?? createConnectionsReader(plugin);
+  plugin.connectionsReader = reader;
+  const view = new ConnectionsView({} as any, plugin, reader);
     (view as any).container = createObsidianLikeContainer();
 
     await view.renderView('note.md');
@@ -205,7 +214,9 @@ describe('ConnectionsView rendering states', () => {
 
   it('refresh button triggers re-embed from loading state', async () => {
     const plugin = createPluginStub();
-    const view = new ConnectionsView({} as any, plugin);
+    const reader = plugin.connectionsReader ?? createConnectionsReader(plugin);
+  plugin.connectionsReader = reader;
+  const view = new ConnectionsView({} as any, plugin, reader);
     (view as any).container = createObsidianLikeContainer();
 
     view.showLoading('Loading...');

--- a/test/connections-view-state.characterization.test.ts
+++ b/test/connections-view-state.characterization.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ConnectionsView } from '../src/ui/ConnectionsView';
+import { createConnectionsReader } from '../src/ui/connections-reader-adapter';
+
+function createPluginStub(overrides: Record<string, unknown> = {}) {
+  return {
+    ready: true,
+    embed_ready: true,
+    status_state: 'idle',
+    settings: {
+      smart_sources: { embed_model: { adapter: 'openai' } },
+      smart_notices: { muted: {} },
+    },
+    embed_adapter: { model_key: 'text-embedding-3-small', dims: 1536 },
+    source_collection: { get: vi.fn(() => null) },
+    block_collection: {
+      all: [] as any[],
+      data_adapter: { save: vi.fn(async () => {}) },
+      for_source(path: string) { return (this.all as any[]).filter((b: any) => b.source_key === path); },
+      import_source_blocks: vi.fn(async () => {}),
+      nearest: vi.fn(async () => []),
+      ensure_entity_vector: vi.fn(async () => {}),
+    },
+    open_note: vi.fn(),
+    runEmbeddingJob: vi.fn(async () => ({})),
+    reembedStaleEntities: vi.fn(async () => 0),
+    pendingReImportPaths: new Set<string>(),
+    getEmbedRuntimeState: vi.fn(() => null),
+    _search_embed_model: { fingerprint: 'fp-1' },
+    _embed_state: { phase: 'idle', modelFingerprint: 'fp-1', lastError: null },
+    ...overrides,
+  } as any;
+}
+
+function createObsidianLikeContainer(): any {
+  const addHelpers = (el: HTMLElement & Record<string, any>) => {
+    const host = el as any;
+    host.empty = function empty() { while (this.firstChild) this.removeChild(this.firstChild); };
+    host.addClass = function addClass(...cls: string[]) { this.classList.add(...cls); };
+    host.removeClass = function removeClass(...cls: string[]) { this.classList.remove(...cls); };
+    host.toggleClass = function toggleClass(cls: string, force: boolean) { this.classList.toggle(cls, force); };
+    host.setText = function setText(text: string) { this.textContent = text; };
+    host.createDiv = function createDiv(opts: Record<string, any> = {}) {
+      const div = document.createElement('div') as HTMLElement & Record<string, any>;
+      if (opts.cls) div.className = opts.cls;
+      if (opts.text) div.textContent = opts.text;
+      this.appendChild(div);
+      addHelpers(div);
+      return div;
+    };
+    host.createSpan = function createSpan(opts: Record<string, any> = {}) { return this.createEl('span', opts); };
+    host.createEl = function createEl(tag: string, opts: Record<string, any> = {}) {
+      const child = document.createElement(tag) as HTMLElement & Record<string, any>;
+      if (opts.cls) child.className = opts.cls;
+      if (opts.text) child.textContent = opts.text;
+      if (opts.attr) for (const [k, v] of Object.entries(opts.attr)) child.setAttribute(k, String(v));
+      this.appendChild(child);
+      addHelpers(child);
+      return child;
+    };
+  };
+
+  const root = document.createElement('div') as HTMLElement & Record<string, any>;
+  addHelpers(root);
+  return root;
+}
+
+function createView(plugin: any) {
+  const reader = plugin.connectionsReader ?? createConnectionsReader(plugin);
+  plugin.connectionsReader = reader;
+  const view = new ConnectionsView({} as any, plugin, reader);
+  (view as any).container = createObsidianLikeContainer();
+  return view;
+}
+
+describe('ConnectionsView renderView characterization baseline', () => {
+  it('shows plugin loading when the plugin is not ready', async () => {
+    const plugin = createPluginStub({ ready: false });
+    const view = createView(plugin);
+
+    await view.renderView('note.md');
+
+    expect(view.container.textContent).toContain('Open Connections is initializing');
+  });
+
+  it('shows pending import when the target path is queued for re-import', async () => {
+    const plugin = createPluginStub();
+    plugin.pendingReImportPaths.add('note.md');
+    const view = createView(plugin);
+
+    await view.renderView('note.md');
+
+    expect(view.container.textContent).toContain('Importing note');
+  });
+
+  it('shows note-too-short when there are no blocks and no source to import', async () => {
+    const plugin = createPluginStub();
+    const view = createView(plugin);
+
+    await view.renderView('note.md');
+
+    expect(view.container.textContent).toContain('Note is too short');
+  });
+
+  it('shows embed loading when blocks exist but no vectors are ready', async () => {
+    const plugin = createPluginStub({ embed_ready: false });
+    plugin.block_collection.all = [{ source_key: 'note.md', has_embed: () => false, queue_embed: vi.fn(), _queue_embed: false }];
+    const view = createView(plugin);
+
+    await view.renderView('note.md');
+
+    expect(view.container.textContent).toContain('Open Connections is loading');
+  });
+
+  it('shows model error when serving is unavailable', async () => {
+    const plugin = createPluginStub({ status_state: 'error', embed_ready: false });
+    plugin.block_collection.all = [{ source_key: 'note.md', has_embed: () => false, queue_embed: vi.fn(), _queue_embed: false }];
+    plugin.getEmbedRuntimeState = vi.fn(() => ({
+      snapshot: { phase: 'error', modelFingerprint: null, lastError: 'boom' },
+      model: { kind: 'unavailable', error: 'boom' },
+      backfill: { kind: 'failed', error: 'boom' },
+      serving: { kind: 'unavailable', error: 'boom' },
+      profiling: {
+        activeStage: null,
+        activeSince: null,
+        recentStages: [],
+        counters: { saveCount: 0, followupScheduledCount: 0, progressEventCount: 0, connectionsViewRenderCount: 0 },
+      },
+    }));
+    const view = createView(plugin);
+
+    await view.renderView('note.md');
+
+    expect(view.container.textContent).toContain('Embedding model failed to initialize');
+  });
+
+  it('shows no connections when nearest-search returns nothing for embedded blocks', async () => {
+    const plugin = createPluginStub();
+    plugin.block_collection.all = [{ source_key: 'note.md', has_embed: () => true, vec: [1, 2, 3], evictVec: vi.fn() }];
+    plugin.block_collection.nearest = vi.fn(async () => []);
+    const view = createView(plugin);
+
+    await view.renderView('note.md');
+
+    expect(view.container.textContent).toContain('No related notes found');
+  });
+});

--- a/test/connections-view-state.reader-injection.test.ts
+++ b/test/connections-view-state.reader-injection.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { deriveConnectionsViewState } from '../src/ui/connections-view-state';
+import type { ConnectionsReader } from '../src/types/connections-reader';
+
+function makeReader(overrides: Partial<ConnectionsReader> = {}): ConnectionsReader {
+  return {
+    isReady: () => true,
+    isEmbedReady: () => true,
+    getStatusState: () => 'ok',
+    hasPendingReImport: () => false,
+    getBlocksForSource: () => [],
+    getSource: () => null,
+    ensureBlocksForSource: async () => [],
+    getConnectionsForSource: async () => [],
+    getEmbedRuntimeState: () => null,
+    getSearchModelFingerprint: () => 'fp-1',
+    getKernelPhase: () => 'idle',
+    isDiscovering: () => false,
+    ...overrides,
+  };
+}
+
+describe('deriveConnectionsViewState — reader driven reads', () => {
+  it('returns plugin_loading when reader.isReady() is false even if plugin.ready is true', async () => {
+    const view: any = {
+      plugin: {
+        ready: true,
+        block_collection: { for_source: () => [] },
+        pendingReImportPaths: new Set<string>(),
+      },
+      reader: makeReader({ isReady: () => false }),
+    };
+
+    const state = await deriveConnectionsViewState(view, 'a.md');
+    expect(state.type).toBe('plugin_loading');
+  });
+
+
+  it('uses reader.getConnectionsForSource for embedded blocks instead of plugin.block_collection queries', async () => {
+    const pluginNearest = vi.fn(async () => { throw new Error('should not call plugin nearest'); });
+    const results = [{ item: { key: 'other.md#A', source_key: 'other.md' }, score: 0.9 }];
+    const view: any = {
+      plugin: {
+        ready: true,
+        block_collection: {
+          for_source: () => [{ has_embed: () => true }],
+          nearest: pluginNearest,
+          ensure_entity_vector: vi.fn(async () => {}),
+        },
+        pendingReImportPaths: new Set<string>(),
+      },
+      reader: makeReader({
+        ensureBlocksForSource: async () => [{ has_embed: () => true }],
+        getConnectionsForSource: async () => results,
+      }),
+    };
+
+    const state = await deriveConnectionsViewState(view, 'a.md');
+    expect(state).toEqual({ type: 'results', path: 'a.md', results });
+    expect(pluginNearest).not.toHaveBeenCalled();
+  });
+
+  it('returns pending_import when the reader reports it, even if plugin pending set is empty', async () => {
+    const view: any = {
+      plugin: {
+        ready: true,
+        block_collection: { for_source: () => [] },
+        pendingReImportPaths: new Set<string>(),
+      },
+      reader: makeReader({ hasPendingReImport: () => true }),
+    };
+
+    const state = await deriveConnectionsViewState(view, 'a.md');
+    expect(state).toEqual({ type: 'pending_import', path: 'a.md' });
+  });
+});

--- a/test/connections-view-swr.integration.test.ts
+++ b/test/connections-view-swr.integration.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { App } from 'obsidian';
+import { ConnectionsView } from '../src/ui/ConnectionsView';
+import { createConnectionsReader } from '../src/ui/connections-reader-adapter';
+import { invalidateConnectionsCache } from '../src/ui/block-connections';
+
+function makeResult(sourcePath: string, score = 0.9) {
+  return {
+    item: { key: `${sourcePath}#Section`, source_key: sourcePath, evictVec: vi.fn() },
+    score,
+  };
+}
+
+function createPluginStub(overrides: Record<string, unknown> = {}) {
+  const nearest = vi
+    .fn()
+    .mockResolvedValueOnce([makeResult('old.md')])
+    .mockResolvedValueOnce([makeResult('new.md')]);
+
+  return {
+    ready: true,
+    embed_ready: true,
+    status_state: 'idle',
+    settings: {
+      smart_sources: { embed_model: { adapter: 'openai' } },
+      smart_notices: { muted: {} },
+    },
+    embed_adapter: { model_key: 'text-embedding-3-small', dims: 1536 },
+    source_collection: { get: vi.fn(() => null) },
+    block_collection: {
+      all: [{ key: 'note.md#Seed', source_key: 'note.md', has_embed: () => true, vec: [1, 2, 3], evictVec: vi.fn() }],
+      data_adapter: { save: vi.fn(async () => {}) },
+      for_source(path: string) { return (this.all as any[]).filter((b: any) => b.source_key === path); },
+      import_source_blocks: vi.fn(async () => {}),
+      nearest,
+      ensure_entity_vector: vi.fn(async () => {}),
+    },
+    open_note: vi.fn(),
+    runEmbeddingJob: vi.fn(async () => ({})),
+    reembedStaleEntities: vi.fn(async () => 0),
+    pendingReImportPaths: new Set<string>(),
+    getEmbedRuntimeState: vi.fn(() => null),
+    _search_embed_model: { fingerprint: 'fp-1' },
+    _embed_state: { phase: 'idle', modelFingerprint: 'fp-1', lastError: null },
+    ...overrides,
+  } as any;
+}
+
+function createObsidianLikeContainer(): any {
+  const addHelpers = (el: HTMLElement & Record<string, any>) => {
+    const host = el as any;
+    host.empty = function empty() { while (this.firstChild) this.removeChild(this.firstChild); };
+    host.addClass = function addClass(...cls: string[]) { this.classList.add(...cls); };
+    host.removeClass = function removeClass(...cls: string[]) { this.classList.remove(...cls); };
+    host.toggleClass = function toggleClass(cls: string, force: boolean) { this.classList.toggle(cls, force); };
+    host.setText = function setText(text: string) { this.textContent = text; };
+    host.createDiv = function createDiv(opts: Record<string, any> = {}) {
+      const div = document.createElement('div') as HTMLElement & Record<string, any>;
+      if (opts.cls) div.className = opts.cls;
+      if (opts.text) div.textContent = opts.text;
+      if (opts.attr) for (const [k, v] of Object.entries(opts.attr)) div.setAttribute(k, String(v));
+      this.appendChild(div);
+      addHelpers(div);
+      return div;
+    };
+    host.createSpan = function createSpan(opts: Record<string, any> = {}) { return this.createEl('span', opts); };
+    host.createEl = function createEl(tag: string, opts: Record<string, any> = {}) {
+      const child = document.createElement(tag) as HTMLElement & Record<string, any>;
+      if (opts.cls) child.className = opts.cls;
+      if (opts.text) child.textContent = opts.text;
+      if (opts.attr) for (const [k, v] of Object.entries(opts.attr)) child.setAttribute(k, String(v));
+      this.appendChild(child);
+      addHelpers(child);
+      return child;
+    };
+  };
+
+  const root = document.createElement('div') as HTMLElement & Record<string, any>;
+  addHelpers(root);
+  return root;
+}
+
+function createView(plugin: any) {
+  const reader = plugin.connectionsReader ?? createConnectionsReader(plugin);
+  plugin.connectionsReader = reader;
+  const view = new ConnectionsView({} as any, plugin, reader);
+  (view as any).container = createObsidianLikeContainer();
+  return view;
+}
+
+beforeEach(() => {
+  invalidateConnectionsCache();
+});
+
+afterEach(() => {
+  invalidateConnectionsCache();
+});
+
+describe('ConnectionsView SWR integration', () => {
+  it('serves the same path + fingerprint from the view cache without re-deriving state', async () => {
+    const plugin = createPluginStub();
+    const view = createView(plugin);
+    const deriveSpy = vi.spyOn(view, 'deriveViewState');
+    const emptySpy = vi.spyOn(view.container, 'empty');
+
+    await view.renderView('note.md');
+    await view.renderView('note.md');
+
+    expect(deriveSpy).toHaveBeenCalledTimes(1);
+    expect(emptySpy).toHaveBeenCalledTimes(1);
+    expect(plugin.block_collection.nearest).toHaveBeenCalledTimes(1);
+    expect(view.container.textContent).toContain('old');
+  });
+
+  it('invalidates cached results when the search fingerprint changes and recomputes fresh results', async () => {
+    const plugin = createPluginStub();
+    const view = createView(plugin);
+    const loadingSpy = vi.spyOn(view, 'showLoading');
+
+    await view.renderView('note.md');
+    expect(view.container.textContent).toContain('old');
+
+    plugin._search_embed_model.fingerprint = 'fp-2';
+    plugin._embed_state.modelFingerprint = 'fp-2';
+
+    await view.renderView('note.md');
+
+    expect(loadingSpy).toHaveBeenCalledWith('Embedding model changed. Re-embedding in progress.');
+    expect(plugin.block_collection.nearest).toHaveBeenCalledTimes(2);
+    expect(view.container.textContent).toContain('new');
+  });
+
+
+  it('always recomputes when the reader cannot provide a fingerprint', async () => {
+    const plugin = createPluginStub({
+      _search_embed_model: { fingerprint: null },
+      _embed_state: { phase: 'idle', modelFingerprint: null, lastError: null },
+    });
+    const view = createView(plugin);
+
+    await view.renderView('note.md');
+    await view.renderView('note.md');
+
+    expect(plugin.block_collection.nearest).toHaveBeenCalledTimes(2);
+  });
+
+  it('bypasses cached results when the path is pending re-import', async () => {
+    const plugin = createPluginStub();
+    const view = createView(plugin);
+
+    await view.renderView('note.md');
+    expect(view.container.textContent).toContain('old');
+
+    plugin.pendingReImportPaths.add('note.md');
+
+    await view.renderView('note.md');
+
+    expect(plugin.block_collection.nearest).toHaveBeenCalledTimes(1);
+    expect(view.container.textContent).toContain('Importing note');
+  });
+
+  it('revalidates exactly once when embed state changes from running to idle', async () => {
+    const app = new App();
+    const plugin = createPluginStub();
+    const reader = plugin.connectionsReader ?? createConnectionsReader(plugin);
+    plugin.connectionsReader = reader;
+    const view = new ConnectionsView({ app } as any, plugin, reader);
+    const root = document.createElement('div');
+    root.appendChild(document.createElement('div'));
+    root.appendChild(createObsidianLikeContainer());
+    (view as any).containerEl = root;
+    app.workspace.getActiveFile = () => null;
+
+    await view.onOpen();
+    await view.renderView('note.md');
+
+    const renderSpy = vi.spyOn(view, 'renderView');
+    app.workspace.trigger('open-connections:embed-state-changed', { prev: 'running', phase: 'idle' });
+    const rerender = renderSpy.mock.results[0]?.value;
+    if (rerender && typeof rerender.then === 'function') await rerender;
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    expect(renderSpy).toHaveBeenCalledWith('note.md');
+    expect(plugin.block_collection.nearest).toHaveBeenCalledTimes(2);
+    expect(view.container.textContent).toContain('new');
+  });
+});

--- a/test/mocks/obsidian.ts
+++ b/test/mocks/obsidian.ts
@@ -18,7 +18,7 @@ export class TFile {
   constructor(path: string) {
     this.path = path;
     const parts = path.split('/');
-    const filename = parts[parts.length - 1];
+    const filename = parts.at(-1) ?? path;
     const dotIndex = filename.lastIndexOf('.');
     this.basename = dotIndex >= 0 ? filename.substring(0, dotIndex) : filename;
     this.extension = dotIndex >= 0 ? filename.substring(dotIndex + 1) : '';
@@ -37,7 +37,7 @@ export class TFolder {
   constructor(path: string) {
     this.path = path;
     const parts = path.split('/');
-    this.name = parts[parts.length - 1];
+    this.name = parts.at(-1) ?? path;
     this.children = [];
   }
 }
@@ -91,6 +91,7 @@ export class MetadataCache {
  */
 export class Workspace {
   activeLeaf: any = null;
+  private listeners: Map<string, Set<(payload?: unknown) => unknown>> = new Map();
 
   getActiveFile(): TFile | null {
     return null;
@@ -107,8 +108,26 @@ export class Workspace {
     };
   }
 
-  on = vi.fn();
-  off = vi.fn();
+  on(name: string, handler: (payload?: unknown) => unknown): { name: string; handler: (payload?: unknown) => unknown } {
+    const listeners = this.listeners.get(name) ?? new Set<(payload?: unknown) => unknown>();
+    listeners.add(handler);
+    this.listeners.set(name, listeners);
+    return { name, handler };
+  }
+
+  off(name: string, handler: (payload?: unknown) => unknown): void {
+    this.listeners.get(name)?.delete(handler);
+  }
+
+  offref(ref: { name: string; handler: (payload?: unknown) => unknown }): void {
+    this.off(ref.name, ref.handler);
+  }
+
+  trigger(name: string, payload?: unknown): void {
+    for (const handler of this.listeners.get(name) ?? []) {
+      handler(payload);
+    }
+  }
 }
 
 /**
@@ -214,7 +233,7 @@ export class ItemView {
   contentEl: HTMLElement = document.createElement('div');
 
   constructor(leaf: any) {
-    this.app = new App();
+    this.app = leaf?.app ?? new App();
   }
 
   getViewType(): string {
@@ -222,7 +241,11 @@ export class ItemView {
   }
 
   getDisplayText(): string {
-    return 'Mock View';
+    return 'Mock view';
+  }
+
+  registerEvent(eventRef: any): any {
+    return eventRef;
   }
 
   async onOpen(): Promise<void> {}
@@ -511,7 +534,7 @@ export class ButtonComponent {
 
   onClick(callback: (evt: MouseEvent) => unknown | Promise<unknown>): this {
     this.buttonEl.addEventListener('click', (evt) => {
-      void callback(evt as MouseEvent);
+      void callback(evt);
     });
     return this;
   }
@@ -547,7 +570,7 @@ export function setIcon(parent: HTMLElement, iconId: string): void {
  */
 export const MarkdownRenderer = {
   renderMarkdown: vi.fn((markdown: string, el: HTMLElement, sourcePath: string, component: Component) => {
-    el.innerHTML = markdown;
+    el.textContent = markdown;
     return Promise.resolve();
   }),
 };

--- a/test/plugin-registration.connections-reader.test.ts
+++ b/test/plugin-registration.connections-reader.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/ui/commands', () => ({ registerCommands: vi.fn() }));
+vi.mock('../src/ui/plugin-codeblock', () => ({ registerSmartConnectionsCodeBlock: vi.fn() }));
+vi.mock('../src/ui/settings', () => ({
+  SmartConnectionsSettingsTab: class SmartConnectionsSettingsTab {
+    constructor(public app: unknown, public plugin: unknown) {}
+  },
+}));
+
+import { App } from 'obsidian';
+import { ConnectionsView, CONNECTIONS_VIEW_TYPE } from '../src/ui/ConnectionsView';
+import { registerPluginUi } from '../src/ui/plugin-registration';
+
+describe('registerPluginUi — ConnectionsView wiring', () => {
+  const registerView = vi.fn();
+  const addSettingTab = vi.fn();
+  const addRibbonIcon = vi.fn();
+
+  const sharedReader = { marker: 'shared-reader' };
+  const plugin = {
+    app: new App(),
+    settings: {},
+    ready: true,
+    embed_ready: true,
+    status_state: 'idle',
+    pendingReImportPaths: new Set<string>(),
+    connectionsReader: sharedReader,
+    registerView,
+    addSettingTab,
+    addRibbonIcon,
+  } as any;
+
+  beforeEach(() => {
+    registerView.mockReset();
+    addSettingTab.mockReset();
+    addRibbonIcon.mockReset();
+  });
+
+  it('registers a ConnectionsView factory that injects a reader', () => {
+    registerPluginUi(plugin);
+
+    const connectionEntry = registerView.mock.calls.find(([type]) => type === CONNECTIONS_VIEW_TYPE);
+    expect(connectionEntry).toBeTruthy();
+
+    const factory = connectionEntry?.[1] as (leaf: unknown) => ConnectionsView;
+    const view = factory({} as any);
+
+    expect(view).toBeInstanceOf(ConnectionsView);
+    expect((view as ConnectionsView & { reader?: unknown }).reader).toBe(sharedReader);
+  });
+});

--- a/test/profile-state-latency-report.test.ts
+++ b/test/profile-state-latency-report.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  percentile,
+  classifyLatencyImpact,
+  summarizeLatencyState,
+} from '../scripts/profile-state-latency-report.mjs';
+
+describe('profile-state-latency-report helpers', () => {
+  it('computes percentiles from ordered and unordered values', () => {
+    expect(percentile([3, 1, 2], 0.5)).toBe(2);
+    expect(percentile([100, 10, 50, 30], 0.95)).toBeGreaterThan(50);
+  });
+
+  it('classifies interactive failures as blockers', () => {
+    expect(classifyLatencyImpact('note-switch-unindexed', [
+      { primaryDurationMs: 1200, timeoutCount: 1, emptyPollCount: 0, freezeDetected: false },
+    ])).toBe('interactive-blocker');
+  });
+
+  it('keeps debounce/background states as background when polls stay responsive', () => {
+    expect(classifyLatencyImpact('new-note-debounce-reimport', [
+      { primaryDurationMs: 11_000, timeoutCount: 0, emptyPollCount: 0, freezeDetected: false },
+    ])).toBe('background');
+  });
+
+  it('summarizes repeated samples with median and worst-case', () => {
+    const summary = summarizeLatencyState(
+      {
+        id: 'note-switch-indexed',
+        label: 'note-switch indexed',
+        codePath: ['src/ui/ConnectionsView.ts', 'src/ui/connections-view-state.ts'],
+      },
+      [
+        { primaryDurationMs: 120, timeoutCount: 0, emptyPollCount: 0, freezeDetected: false },
+        { primaryDurationMs: 180, timeoutCount: 0, emptyPollCount: 0, freezeDetected: false },
+        { primaryDurationMs: 160, timeoutCount: 0, emptyPollCount: 0, freezeDetected: false },
+      ],
+    );
+
+    expect(summary).toMatchObject({
+      id: 'note-switch-indexed',
+      sampleCount: 3,
+      medianMs: 160,
+      worstCaseMs: 180,
+      impact: 'background',
+    });
+    expect(summary.explanation).toContain('best-case note-switch path');
+  });
+});

--- a/test/workspace-trigger.test.ts
+++ b/test/workspace-trigger.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Workspace } from 'obsidian';
+
+describe('Workspace trigger mock', () => {
+  it('dispatches payloads to registered handlers and supports offref cleanup', () => {
+    const workspace = new Workspace();
+    const handler = vi.fn();
+
+    const ref = workspace.on('open-connections:embed-state-changed', handler);
+    workspace.trigger('open-connections:embed-state-changed', { prev: 'running', phase: 'idle' });
+
+    expect(handler).toHaveBeenCalledWith({ prev: 'running', phase: 'idle' });
+
+    workspace.offref(ref);
+    workspace.trigger('open-connections:embed-state-changed', { prev: 'running', phase: 'idle' });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- route the ConnectionsView render path through a mandatory `ConnectionsReader` seam owned by the plugin composition root
- add pure `ConnectionsResultCache` and `decideRender` modules, then wire SWR-style cached re-entry, fingerprint invalidation, and running→idle revalidation into the connections view
- add characterization, seam, SWR integration, and `Workspace.trigger()` tests plus update the Slice 1 spec/plan docs to match the final boundary rules

## Functional changes
- reopening the same note with the same fingerprint now reuses cached connection results instead of flashing loading/results again
- changing the embedding fingerprint now invalidates cached connection results and shows the model-change loading banner before fresh results arrive
- a pending re-import path now bypasses cached results so the view shows import/embedding progress instead of stale data
- an embed-state transition from `running` to `idle` now invalidates the path cache and triggers exactly one re-render

## Verification
- `pnpm run ci`
- targeted `src/domain/connections/*.ts` coverage: 100 statements / 100 branches / 100 functions / 100 lines

## Notes
- `manifest.json` had an unrelated pre-existing local modification and was intentionally excluded from this PR.
- Related: #74