### PR TITLE
Use native folder picking and text-first loading states

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -398,20 +398,6 @@
   margin: 0;
 }
 
-/* Spinner */
-.osc-spinner {
-  width: 24px;
-  height: 24px;
-  border: 2px solid var(--background-modifier-border);
-  border-top-color: var(--interactive-accent, #7f6df2);
-  border-radius: 50%;
-  animation: osc-spin 0.6s linear infinite;
-}
-
-@keyframes osc-spin {
-  to { transform: rotate(360deg); }
-}
-
 /* ─── Advanced (Collapsible) Section ─── */
 .osc-advanced-section {
   margin: 8px 0 4px;

--- a/src/ui/ConnectionsView.ts
+++ b/src/ui/ConnectionsView.ts
@@ -197,7 +197,7 @@ export class ConnectionsView extends ItemView {
     }
   }
 
-  showLoading(message = 'Loading...'): void { showConnectionsLoading(this, message); }
+  showLoading(message = 'Loading…'): void { showConnectionsLoading(this, message); }
   showEmpty(message = 'No similar notes found', clear = true): void { showConnectionsEmpty(this, message, clear); }
   showError(message = 'An error occurred'): void { showConnectionsError(this, message); }
   renderResults(targetPath: string, results: ConnectionResult[]): void { renderConnectionsResults(this, targetPath, results); }

--- a/src/ui/LookupView.ts
+++ b/src/ui/LookupView.ts
@@ -124,11 +124,11 @@ export class LookupView extends ItemView {
 
     this.lastQuery = query;
     if (!this.plugin.embed_ready || !this.plugin.embed_adapter) {
-      this.showLoading('Embedding model is still loading...');
+      this.showLoading('Embedding model is still loading…');
       return;
     }
 
-    this.showLoading(`Searching across ${getLookupEntityCount(this.plugin, this.activeFilter)} items...`);
+    this.showLoading(`Searching across ${getLookupEntityCount(this.plugin, this.activeFilter)} items…`);
     const startTime = performance.now();
 
     try {
@@ -159,7 +159,7 @@ export class LookupView extends ItemView {
 
   renderResults(query: string, results: ConnectionResult[], elapsedMs?: number): void { renderLookupResults(this.createRenderContext(), query, results, elapsedMs); }
 
-  showLoading(message = 'Loading...'): void { showLookupLoading(this.createRenderContext(), message); }
+  showLoading(message = 'Loading…'): void { showLookupLoading(this.createRenderContext(), message); }
 
   showEmpty(message = 'No results', clear = true): void { showLookupEmpty(this.createRenderContext(), message, clear); }
 

--- a/src/ui/connections-view-results.ts
+++ b/src/ui/connections-view-results.ts
@@ -80,12 +80,11 @@ export function renderConnectionsResults(
   updateConnectionsProgressBanner(view);
 }
 
-export function showConnectionsLoading(view: ConnectionsView, message = 'Loading...'): void {
+export function showConnectionsLoading(view: ConnectionsView, message = 'Loading…'): void {
   view._lastResultKeys = [];
   clearEmbedProgress(view);
   view.container.empty();
   const wrapper = view.container.createDiv({ cls: 'osc-state' });
-  wrapper.createDiv({ cls: 'osc-spinner' });
   wrapper.createEl('p', { text: message, cls: 'osc-state-text' });
   if (!view.plugin.ready) return;
   new ButtonComponent(wrapper)

--- a/src/ui/connections-view-state.ts
+++ b/src/ui/connections-view-state.ts
@@ -69,13 +69,13 @@ export function applyConnectionsViewState(view: ConnectionsView, state: ViewStat
       view.showEmpty('No active file');
       return;
     case 'plugin_loading':
-      view.showLoading('Open Connections is initializing...');
+      view.showLoading('Open Connections is initializing…');
       return;
     case 'model_error':
       view.showError(EMBED_ERROR_MSG);
       return;
     case 'embed_loading':
-      view.showLoading('Open Connections is loading... Connections will appear when embedding is complete.');
+      view.showLoading('Open Connections is loading… Connections will appear when embedding is complete.');
       return;
     case 'embed_degraded':
       view.showError(state.error ? `${EMBED_DEGRADED_MSG}
@@ -83,13 +83,13 @@ export function applyConnectionsViewState(view: ConnectionsView, state: ViewStat
 Last error: ${state.error}` : EMBED_DEGRADED_MSG);
       return;
     case 'pending_import':
-      view.showLoading('Importing note... Connections will appear when embedding is complete.');
+      view.showLoading('Importing note… Connections will appear when embedding is complete.');
       return;
     case 'note_too_short':
       view.showEmpty('Note is too short to find connections.');
       return;
     case 'embedding_in_progress':
-      view.showLoading('Embedding this note... Results will appear when ready.');
+      view.showLoading('Embedding this note… Results will appear when ready.');
       return;
     case 'no_connections':
       view.showEmpty('No related notes found.');

--- a/src/ui/folder-exclusion-modal.ts
+++ b/src/ui/folder-exclusion-modal.ts
@@ -1,8 +1,7 @@
-import { ButtonComponent, Modal, Setting, type App } from 'obsidian';
+import { FuzzySuggestModal, type App } from 'obsidian';
 
-export class FolderExclusionPickerModal extends Modal {
+export class FolderExclusionPickerModal extends FuzzySuggestModal<string> {
   private resolvePromise!: (value: string | null) => void;
-  private searchValue = '';
   private resolved = false;
 
   constructor(
@@ -10,35 +9,15 @@ export class FolderExclusionPickerModal extends Modal {
     private readonly folderPaths: string[],
   ) {
     super(app);
-  }
-
-  onOpen(): void {
-    const { contentEl } = this;
-    contentEl.empty();
-    contentEl.createEl('h3', { text: 'Select folder to exclude' });
-
-    const searchSetting = new Setting(contentEl)
-      .setName('Find folder')
-      .setDesc('Choose a folder path from the current vault.');
-
-    searchSetting.addText((text) => {
-      text.setPlaceholder('Type to filter folders');
-      text.onChange((value) => {
-        this.searchValue = value.trim().toLowerCase();
-        this.renderFolderList();
-      });
-    });
-
-    contentEl.createDiv({ cls: 'osc-folder-picker-list' });
-    this.renderFolderList();
+    this.setPlaceholder('Type to search vault folders…');
   }
 
   onClose(): void {
-    this.contentEl.empty();
     if (!this.resolved) {
       this.resolvePromise(null);
       this.resolved = true;
     }
+    super.onClose();
   }
 
   openModal(): Promise<string | null> {
@@ -48,43 +27,16 @@ export class FolderExclusionPickerModal extends Modal {
     });
   }
 
-  private renderFolderList(): void {
-    const list = this.contentEl.querySelector<HTMLElement>('.osc-folder-picker-list');
-    if (!list) return;
-    list.empty();
+  getItems(): string[] {
+    return this.folderPaths;
+  }
 
-    const folders = this.folderPaths.filter((path) => {
-      if (!this.searchValue) return true;
-      return path.toLowerCase().includes(this.searchValue);
-    });
+  getItemText(folderPath: string): string {
+    return folderPath;
+  }
 
-    if (folders.length === 0) {
-      list.createEl('p', { text: 'No matching folders found.', cls: 'setting-item-description' });
-      return;
-    }
-
-    for (const folderPath of folders) {
-      new Setting(list)
-        .setName(folderPath)
-        .addButton((button) => {
-          button
-            .setButtonText('Select')
-            .setCta()
-            .onClick(() => {
-              this.resolved = true;
-              this.resolvePromise(folderPath);
-              this.close();
-            });
-        });
-    }
-
-    const footer = list.createDiv({ cls: 'modal-button-container' });
-    new ButtonComponent(footer)
-      .setButtonText('Cancel')
-      .onClick(() => {
-        this.resolved = true;
-        this.resolvePromise(null);
-        this.close();
-      });
+  onChooseItem(folderPath: string): void {
+    this.resolved = true;
+    this.resolvePromise(folderPath);
   }
 }

--- a/src/ui/lookup-view-render.ts
+++ b/src/ui/lookup-view-render.ts
@@ -150,10 +150,9 @@ export function renderLookupResults(
   }
 }
 
-export function showLookupLoading(view: LookupViewRenderContext, message = 'Loading...'): void {
+export function showLookupLoading(view: LookupViewRenderContext, message = 'Loading…'): void {
   clearElement(view.resultsContainer);
   const wrapper = createDiv(view.resultsContainer, { cls: 'osc-state' });
-  createDiv(wrapper, { cls: 'osc-spinner' });
   createElement(wrapper, 'p', { text: message, cls: 'osc-state-text osc-lookup-loading-text' });
 }
 

--- a/src/ui/plugin-codeblock.ts
+++ b/src/ui/plugin-codeblock.ts
@@ -17,7 +17,7 @@ function parseCodeblockConfig(source: string): Record<string, string> {
 export function registerSmartConnectionsCodeBlock(plugin: SmartConnectionsPlugin): void {
   plugin.registerMarkdownCodeBlockProcessor('smart-connections', async (source, el) => {
     if (!plugin.block_collection) {
-      el.createEl('p', { text: 'Open connections is loading...', cls: 'osc-state-text' });
+      el.createEl('p', { text: 'Open connections is loading…', cls: 'osc-state-text' });
       return;
     }
 

--- a/src/ui/status-bar.ts
+++ b/src/ui/status-bar.ts
@@ -66,8 +66,8 @@ export function refreshStatus(plugin: SmartConnectionsPlugin): void {
 
   if (!plugin.block_collection) {
     setStatusIcon(plugin, 'network');
-    plugin.status_msg.setText('Oc: loading...');
-    plugin.status_container.setAttribute('title', 'Open connections is loading...');
+    plugin.status_msg.setText('Oc: loading…');
+    plugin.status_container.setAttribute('title', 'Open connections is loading…');
     return;
   }
 

--- a/test/mocks/obsidian.ts
+++ b/test/mocks/obsidian.ts
@@ -300,6 +300,24 @@ export class Modal extends Component {
   onClose(): void {}
 }
 
+export class FuzzySuggestModal<T> extends Modal {
+  placeholder = '';
+
+  setPlaceholder(value: string): void {
+    this.placeholder = value;
+  }
+
+  getItems(): T[] {
+    return [];
+  }
+
+  getItemText(_item: T): string {
+    return '';
+  }
+
+  onChooseItem(_item: T): void {}
+}
+
 /**
  * Mock Notice
  */
@@ -606,6 +624,7 @@ export default {
   ItemView,
   Component,
   Modal,
+  FuzzySuggestModal,
   Notice,
   DropdownComponent,
   TextComponent,


### PR DESCRIPTION
## Summary
- replace the bespoke folder exclusion picker with a `FuzzySuggestModal`-based picker
- remove spinner-based loading UI in favor of text + ellipsis loading states
- keep the exclusion confirmation flow and refresh behavior unchanged

## Issues
- Closes #79
- Closes #80

## Verification
- `pnpm run ci`