### PR TITLE
fix: unblock local embedding adapters for desktop release

### DIFF
--- a/src/domain/entities/EmbeddingBlock.ts
+++ b/src/domain/entities/EmbeddingBlock.ts
@@ -7,6 +7,7 @@
 import { EmbeddingEntity } from './EmbeddingEntity';
 import type { BlockData, EntityData } from '../../types/entities';
 import { getParagraphCoverage } from './block-paragraph-coverage';
+import { truncateEmbedInput } from './embed-input-limit';
 import type { BlockCollection } from './BlockCollection';
 import type { EntityCollection } from './EntityCollection';
 import type { EmbeddingSource } from './EmbeddingSource';
@@ -86,7 +87,7 @@ export class EmbeddingBlock extends EmbeddingEntity {
       content = await this.read();
     }
 
-    this._embed_input = `${this.breadcrumbs}\n${content}`;
+    this._embed_input = truncateEmbedInput(`${this.breadcrumbs}\n${content}`);
   }
 
   // Getters

--- a/src/domain/entities/embed-input-limit.ts
+++ b/src/domain/entities/embed-input-limit.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_EMBED_INPUT_MAX_CHARS = Math.floor(500 * 3.7);
+
+export function truncateEmbedInput(input: string): string {
+  return input.substring(0, DEFAULT_EMBED_INPUT_MAX_CHARS);
+}

--- a/src/domain/entities/embedding-source-content.ts
+++ b/src/domain/entities/embedding-source-content.ts
@@ -1,6 +1,7 @@
 import { create_hash } from '../../utils';
 import type { EmbeddingSource } from './EmbeddingSource';
 import type { TFileShim as TFile } from '../../types/obsidian-shims';
+import { truncateEmbedInput } from './embed-input-limit';
 
 export async function readEmbeddingSource(source: EmbeddingSource): Promise<string> {
   if (!source.vault || !source.file) return '';
@@ -25,8 +26,7 @@ export async function cacheEmbeddingSourceInput(
   }
 
   const breadcrumbs = source.path.split('/').join(' > ').replace('.md', '');
-  const max_chars = Math.floor(500 * 3.7);
-  source._embed_input = `${breadcrumbs}:\n${content}`.substring(0, max_chars);
+  source._embed_input = truncateEmbedInput(`${breadcrumbs}:\n${content}`);
 }
 
 export async function updateEmbeddingSourceFromFile(

--- a/src/ui/embed-adapters/api-adapter-batch.ts
+++ b/src/ui/embed-adapters/api-adapter-batch.ts
@@ -38,7 +38,7 @@ export async function embed_api_batch(
   adapter: EmbedModelApiAdapter,
   inputs: (EmbedInput | { _embed_input: string })[],
 ): Promise<EmbedResult[]> {
-  if (!adapter.api_key) throw new Error('API key not set');
+  if (adapter.requires_api_key && !adapter.api_key) throw new Error('API key not set');
 
   const normalized: Array<{ item: EmbedInput; originalIndex: number }> = [];
   for (let i = 0; i < inputs.length; i++) {

--- a/src/ui/embed-adapters/api-adapter-request.ts
+++ b/src/ui/embed-adapters/api-adapter-request.ts
@@ -18,10 +18,14 @@ export function resolve_tokenizer_provider(
 }
 
 export function prepare_request_headers(api_key?: string): Record<string, string> {
-  return {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${api_key}`,
-  };
+  return api_key
+    ? {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${api_key}`,
+      }
+    : {
+        'Content-Type': 'application/json',
+      };
 }
 
 export async function request_api(

--- a/src/ui/embed-adapters/api-base.ts
+++ b/src/ui/embed-adapters/api-base.ts
@@ -47,6 +47,7 @@ export class EmbedModelApiAdapter {
   get req_adapter(): typeof EmbedModelRequestAdapter { return EmbedModelRequestAdapter; }
   get res_adapter(): typeof EmbedModelResponseAdapter { return EmbedModelResponseAdapter; }
   get endpoint(): string | undefined { return this.models[this.model_key]?.endpoint; }
+  get requires_api_key(): boolean { return true; }
   get api_key(): string | undefined {
     return (this.settings[`${this.adapter}.api_key`] as string | undefined) || (this.settings.api_key as string | undefined);
   }

--- a/src/ui/embed-adapters/lm-studio.ts
+++ b/src/ui/embed-adapters/lm-studio.ts
@@ -52,6 +52,10 @@ export class LmStudioEmbedAdapter extends EmbedModelApiAdapter {
     return `${this.host}/api/v0/embeddings`;
   }
 
+  get requires_api_key(): boolean {
+    return false;
+  }
+
   get models_endpoint(): string {
     return `${this.host}/api/v0/models`;
   }

--- a/src/ui/embed-adapters/ollama.ts
+++ b/src/ui/embed-adapters/ollama.ts
@@ -35,6 +35,14 @@ export class OllamaEmbedAdapter extends EmbedModelApiAdapter {
     return `${this.host}/api/embed`;
   }
 
+  get requires_api_key(): boolean {
+    return false;
+  }
+
+  get max_tokens(): number {
+    return this.models[this.model_key]?.max_tokens || 2048;
+  }
+
   get models_endpoint(): string {
     return `${this.host}/api/tags`;
   }

--- a/test/api-adapter-batch.test.ts
+++ b/test/api-adapter-batch.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { embed_api_batch } from '../src/ui/embed-adapters/api-adapter-batch';
+import { LmStudioEmbedAdapter } from '../src/ui/embed-adapters/lm-studio';
+import { OllamaEmbedAdapter } from '../src/ui/embed-adapters/ollama';
+import { OpenAIEmbedAdapter, OPENAI_EMBED_MODELS } from '../src/ui/embed-adapters/openai';
+
+function stubLocalAdapter(adapter: OllamaEmbedAdapter | LmStudioEmbedAdapter, response: unknown): void {
+  adapter.prepare_embed_input = vi.fn(async (input: string) => input);
+  adapter.count_tokens = vi.fn(async () => 1);
+  adapter.request = vi.fn(async () => response);
+}
+
+describe('embed_api_batch auth gating', () => {
+  it('still requires an API key for OpenAI adapters', async () => {
+    const adapter = new OpenAIEmbedAdapter({
+      adapter: 'openai',
+      model_key: 'text-embedding-3-small',
+      dims: 1536,
+      models: OPENAI_EMBED_MODELS,
+      settings: {},
+    });
+
+    await expect(embed_api_batch(adapter, [{ embed_input: 'hello' }])).rejects.toThrow('API key not set');
+  });
+
+  it('allows Ollama adapters to embed without an API key', async () => {
+    const adapter = new OllamaEmbedAdapter({
+      adapter: 'ollama',
+      model_key: 'nomic-embed-text',
+      dims: 768,
+      models: {},
+      settings: {},
+    });
+    stubLocalAdapter(adapter, { embeddings: [[1, 2, 3]], prompt_eval_count: 3 });
+
+    await expect(embed_api_batch(adapter, [{ embed_input: 'hello' }])).resolves.toEqual([
+      { embed_input: 'hello', vec: [1, 2, 3], tokens: 3 },
+    ]);
+  });
+
+  it('allows LM Studio adapters to embed without an API key', async () => {
+    const adapter = new LmStudioEmbedAdapter({
+      adapter: 'lm_studio',
+      model_key: 'text-embedding',
+      dims: 768,
+      models: {},
+      settings: {},
+    });
+    stubLocalAdapter(adapter, { data: [{ embedding: [4, 5] }] });
+
+    await expect(embed_api_batch(adapter, [{ embed_input: 'hello' }])).resolves.toEqual([
+      { embed_input: 'hello', vec: [4, 5], tokens: 0 },
+    ]);
+  });
+
+  it('omits authorization headers when a local adapter has no API key', () => {
+    const adapter = new LmStudioEmbedAdapter({
+      adapter: 'lm_studio',
+      model_key: 'text-embedding',
+      dims: 768,
+      models: {},
+      settings: {},
+    });
+    const requestAdapter = new adapter.req_adapter(adapter, ['hello']);
+    const request = requestAdapter.to_platform();
+
+    expect(request.headers).toEqual({ 'Content-Type': 'application/json' });
+  });
+});

--- a/test/embedding-block-input.test.ts
+++ b/test/embedding-block-input.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { EmbeddingBlock } from '../src/domain/entities/EmbeddingBlock';
+import { DEFAULT_EMBED_INPUT_MAX_CHARS } from '../src/domain/entities/embed-input-limit';
+
+describe('EmbeddingBlock.get_embed_input', () => {
+  it('caps block input length to the shared embedding input ceiling', async () => {
+    const block = new EmbeddingBlock({
+      settings: {},
+      embed_model_key: 'test-model',
+    } as any, {
+      path: 'folder/note.md#heading',
+      text: '',
+      length: 5000,
+      embeddings: {},
+    });
+
+    await block.get_embed_input('a'.repeat(DEFAULT_EMBED_INPUT_MAX_CHARS * 2));
+
+    expect(block._embed_input).toBeDefined();
+    expect(block._embed_input!.length).toBe(DEFAULT_EMBED_INPUT_MAX_CHARS);
+    expect(block._embed_input).toContain('folder > note');
+  });
+});

--- a/test/ollama-adapter.test.ts
+++ b/test/ollama-adapter.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { OllamaEmbedAdapter } from '../src/ui/embed-adapters/ollama';
+
+describe('OllamaEmbedAdapter safeguards', () => {
+  it('uses a conservative default max token budget before model metadata loads', () => {
+    const adapter = new OllamaEmbedAdapter({
+      adapter: 'ollama',
+      model_key: 'nomic-embed-text',
+      dims: 768,
+      models: {},
+      settings: {},
+    });
+
+    expect(adapter.max_tokens).toBe(2048);
+  });
+});


### PR DESCRIPTION
## Summary
- lets Ollama and LM Studio bypass the API-key gate while still keeping remote adapters keyed
- omits the Authorization header entirely when no API key is configured
- reuses one shared input-length cap for source and block embedding payloads
- adds focused regressions for local-adapter auth, block input truncation, and Ollama default token ceiling

## Release scope
This branch intentionally handles the current desktop release blocker from PR #84.

PR #83 remains valid mobile-safe storage work, but it is intentionally excluded here because the plugin is still desktop-only (`manifest.json`), and that storage/runtime change is materially broader risk than this adapter-focused fix.

## Validation
- `pnpm vitest run test/api-adapter-batch.test.ts test/embedding-block-input.test.ts test/ollama-adapter.test.ts`
- `pnpm run ci`

## Notes
- `manifest.json` formatting-only churn was kept out of the branch.
- Live Ollama / LM Studio server round-trips were not exercised in this branch; coverage is regression + full CI.